### PR TITLE
feat(backend): agent domain features (SB-003)

### DIFF
--- a/backend/features/__init__.py
+++ b/backend/features/__init__.py
@@ -1,5 +1,7 @@
 # Model registry — import all feature models here for alembic discovery
+from features.agent_definitions.models import AgentDefinition  # noqa: F401
 from features.conversations.models import Conversation  # noqa: F401
 from features.message_parts.models import MessagePart  # noqa: F401
 from features.messages.models import Message  # noqa: F401
+from features.role_templates.models import RoleTemplate  # noqa: F401
 from features.tool_calls.models import ToolCall  # noqa: F401

--- a/backend/features/agent_definitions/__init__.py
+++ b/backend/features/agent_definitions/__init__.py
@@ -1,0 +1,13 @@
+from .models import AgentDefinition
+from .schemas.input import AgentDefinitionCreate, AgentDefinitionUpdate
+from .schemas.output import AgentDefinitionResponse, AgentDefinitionSummary
+from .service import AgentDefinitionService
+
+__all__ = [
+    "AgentDefinition",
+    "AgentDefinitionCreate",
+    "AgentDefinitionUpdate",
+    "AgentDefinitionResponse",
+    "AgentDefinitionSummary",
+    "AgentDefinitionService",
+]

--- a/backend/features/agent_definitions/models.py
+++ b/backend/features/agent_definitions/models.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from pattern_stack.atoms.patterns import BasePattern, Field
+
+
+class AgentDefinition(BasePattern):  # type: ignore[misc]
+    __tablename__ = "agent_definitions"
+
+    class Pattern:
+        entity = "agent_definition"
+        reference_prefix = "AGNT"
+        track_changes = True
+
+    name = Field(str, required=True, max_length=100, unique=True, index=True)
+    role_template_id = Field(UUID, foreign_key="role_templates.id", required=True, index=True)
+    model_override = Field(str, nullable=True, max_length=100)
+    mission = Field(str, required=True)
+    background = Field(str, nullable=True)
+    awareness = Field(dict, default=dict)
+    is_active = Field(bool, default=True, index=True)

--- a/backend/features/agent_definitions/schemas/__init__.py
+++ b/backend/features/agent_definitions/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .input import AgentDefinitionCreate, AgentDefinitionUpdate
+from .output import AgentDefinitionResponse, AgentDefinitionSummary
+
+__all__ = ["AgentDefinitionCreate", "AgentDefinitionUpdate", "AgentDefinitionResponse", "AgentDefinitionSummary"]

--- a/backend/features/agent_definitions/schemas/input.py
+++ b/backend/features/agent_definitions/schemas/input.py
@@ -1,0 +1,25 @@
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+
+class AgentDefinitionCreate(BaseModel):
+    name: str = PydanticField(..., min_length=1, max_length=100)
+    role_template_id: UUID
+    model_override: str | None = None
+    mission: str = PydanticField(..., min_length=1)
+    background: str | None = None
+    awareness: dict[str, Any] = PydanticField(default_factory=dict)
+    is_active: bool = True
+
+
+class AgentDefinitionUpdate(BaseModel):
+    name: str | None = None
+    role_template_id: UUID | None = None
+    model_override: str | None = None
+    mission: str | None = None
+    background: str | None = None
+    awareness: dict[str, Any] | None = None
+    is_active: bool | None = None

--- a/backend/features/agent_definitions/schemas/output.py
+++ b/backend/features/agent_definitions/schemas/output.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class AgentDefinitionResponse(BaseModel):
+    id: UUID
+    reference_number: str | None = None
+    name: str
+    role_template_id: UUID
+    model_override: str | None = None
+    mission: str
+    background: str | None = None
+    awareness: dict[str, Any]
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AgentDefinitionSummary(BaseModel):
+    id: UUID
+    name: str
+    is_active: bool
+
+    model_config = {"from_attributes": True}

--- a/backend/features/agent_definitions/service.py
+++ b/backend/features/agent_definitions/service.py
@@ -1,0 +1,20 @@
+from pattern_stack.atoms.patterns.services import BaseService
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import AgentDefinition
+from .schemas.input import AgentDefinitionCreate, AgentDefinitionUpdate
+
+
+class AgentDefinitionService(BaseService[AgentDefinition, AgentDefinitionCreate, AgentDefinitionUpdate]):  # type: ignore[misc]
+    model = AgentDefinition
+
+    async def get_by_name(self, db: AsyncSession, name: str) -> AgentDefinition | None:
+        result = await db.execute(select(AgentDefinition).where(AgentDefinition.name == name))
+        return result.scalar_one_or_none()
+
+    async def list_active(self, db: AsyncSession) -> list[AgentDefinition]:
+        result = await db.execute(
+            select(AgentDefinition).where(AgentDefinition.is_active == True)  # noqa: E712
+        )
+        return list(result.scalars().all())

--- a/backend/features/role_templates/__init__.py
+++ b/backend/features/role_templates/__init__.py
@@ -1,0 +1,13 @@
+from .models import RoleTemplate
+from .schemas.input import RoleTemplateCreate, RoleTemplateUpdate
+from .schemas.output import RoleTemplateResponse, RoleTemplateSummary
+from .service import RoleTemplateService
+
+__all__ = [
+    "RoleTemplate",
+    "RoleTemplateCreate",
+    "RoleTemplateUpdate",
+    "RoleTemplateResponse",
+    "RoleTemplateSummary",
+    "RoleTemplateService",
+]

--- a/backend/features/role_templates/models.py
+++ b/backend/features/role_templates/models.py
@@ -1,0 +1,20 @@
+from pattern_stack.atoms.patterns import BasePattern, Field
+
+
+class RoleTemplate(BasePattern):  # type: ignore[misc]
+    __tablename__ = "role_templates"
+
+    class Pattern:
+        entity = "role_template"
+        reference_prefix = "ROLE"
+        track_changes = True
+
+    name = Field(str, required=True, max_length=100, unique=True, index=True)
+    source = Field(str, default="custom", max_length=20)
+    archetype = Field(str, nullable=True, max_length=100)
+    default_model = Field(str, nullable=True, max_length=100)
+    persona = Field(dict, default=dict)
+    judgments = Field(list, default=list)
+    responsibilities = Field(list, default=list)
+    description = Field(str, nullable=True)
+    is_active = Field(bool, default=True, index=True)

--- a/backend/features/role_templates/schemas/__init__.py
+++ b/backend/features/role_templates/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .input import RoleTemplateCreate, RoleTemplateUpdate
+from .output import RoleTemplateResponse, RoleTemplateSummary
+
+__all__ = ["RoleTemplateCreate", "RoleTemplateUpdate", "RoleTemplateResponse", "RoleTemplateSummary"]

--- a/backend/features/role_templates/schemas/input.py
+++ b/backend/features/role_templates/schemas/input.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic import Field as PydanticField
+
+
+class RoleTemplateCreate(BaseModel):
+    name: str = PydanticField(..., min_length=1, max_length=100)
+    source: str = "custom"
+    archetype: str | None = None
+    default_model: str | None = None
+    persona: dict[str, Any] = PydanticField(default_factory=dict)
+    judgments: list[Any] = PydanticField(default_factory=list)
+    responsibilities: list[Any] = PydanticField(default_factory=list)
+    description: str | None = None
+    is_active: bool = True
+
+
+class RoleTemplateUpdate(BaseModel):
+    name: str | None = None
+    source: str | None = None
+    archetype: str | None = None
+    default_model: str | None = None
+    persona: dict[str, Any] | None = None
+    judgments: list[Any] | None = None
+    responsibilities: list[Any] | None = None
+    description: str | None = None
+    is_active: bool | None = None

--- a/backend/features/role_templates/schemas/output.py
+++ b/backend/features/role_templates/schemas/output.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class RoleTemplateResponse(BaseModel):
+    id: UUID
+    reference_number: str | None = None
+    name: str
+    source: str
+    archetype: str | None = None
+    default_model: str | None = None
+    persona: dict[str, Any]
+    judgments: list[Any]
+    responsibilities: list[Any]
+    description: str | None = None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class RoleTemplateSummary(BaseModel):
+    id: UUID
+    name: str
+    archetype: str | None = None
+    is_active: bool
+
+    model_config = {"from_attributes": True}

--- a/backend/features/role_templates/service.py
+++ b/backend/features/role_templates/service.py
@@ -1,0 +1,14 @@
+from pattern_stack.atoms.patterns.services import BaseService
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import RoleTemplate
+from .schemas.input import RoleTemplateCreate, RoleTemplateUpdate
+
+
+class RoleTemplateService(BaseService[RoleTemplate, RoleTemplateCreate, RoleTemplateUpdate]):  # type: ignore[misc]
+    model = RoleTemplate
+
+    async def get_by_name(self, db: AsyncSession, name: str) -> RoleTemplate | None:
+        result = await db.execute(select(RoleTemplate).where(RoleTemplate.name == name))
+        return result.scalar_one_or_none()

--- a/backend/seeds/agents.yaml
+++ b/backend/seeds/agents.yaml
@@ -1,0 +1,86 @@
+role_templates:
+  - name: understander
+    source: library
+    archetype: Analyst
+    default_model: claude-sonnet-4-20250514
+    persona:
+      traits: ["analytical", "thorough", "curious"]
+    responsibilities:
+      - Analyze requirements and user intent
+      - Identify ambiguities and ask clarifying questions
+      - Produce clear problem statements
+    description: "Analyzes and understands requirements, producing clear problem statements."
+
+  - name: planner
+    source: library
+    archetype: Architect
+    default_model: claude-sonnet-4-20250514
+    persona:
+      traits: ["strategic", "systematic", "pragmatic"]
+    responsibilities:
+      - Design implementation approach
+      - Identify risks and dependencies
+      - Create actionable plans
+    description: "Designs implementation plans with clear steps and risk assessment."
+
+  - name: specifier
+    source: library
+    archetype: Writer
+    default_model: claude-sonnet-4-20250514
+    persona:
+      traits: ["precise", "detail-oriented", "structured"]
+    responsibilities:
+      - Write detailed specifications
+      - Define acceptance criteria
+      - Document edge cases
+    description: "Writes detailed implementation specifications."
+
+  - name: implementer
+    source: library
+    archetype: Implementer
+    default_model: claude-sonnet-4-20250514
+    persona:
+      traits: ["focused", "efficient", "quality-minded"]
+    responsibilities:
+      - Write production code
+      - Follow coding standards
+      - Write tests
+    description: "Implements code following specifications and best practices."
+
+  - name: reviewer
+    source: library
+    archetype: Reviewer
+    default_model: claude-sonnet-4-20250514
+    persona:
+      traits: ["critical", "constructive", "thorough"]
+    responsibilities:
+      - Review code for correctness
+      - Check architecture compliance
+      - Verify test coverage
+    description: "Reviews implementations for quality, correctness, and compliance."
+
+agent_definitions:
+  - name: understander
+    role_template: understander
+    mission: "Analyze the given task or issue to produce a clear understanding of what needs to be done, why, and what constraints exist."
+    background: "Expert requirements analyst with deep software engineering knowledge."
+
+  - name: planner
+    role_template: planner
+    mission: "Create an actionable implementation plan that balances quality with delivery speed."
+    background: "Senior software architect experienced in incremental delivery."
+
+  - name: specifier
+    role_template: specifier
+    mission: "Write a detailed implementation specification that a builder can follow without ambiguity."
+    background: "Technical writer and software designer focused on clarity."
+
+  - name: implementer
+    role_template: implementer
+    mission: "Implement the specified changes with high code quality, following project conventions."
+    background: "Senior full-stack developer with expertise in Python and TypeScript."
+
+  - name: reviewer
+    role_template: reviewer
+    mission: "Validate the implementation against the specification, architecture rules, and quality standards."
+    background: "Staff engineer focused on code quality and architecture compliance."

--- a/backend/tests/features/test_agent_definitions.py
+++ b/backend/tests/features/test_agent_definitions.py
@@ -1,0 +1,140 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from features.agent_definitions.models import AgentDefinition
+from features.agent_definitions.schemas.input import AgentDefinitionCreate, AgentDefinitionUpdate
+from features.agent_definitions.schemas.output import AgentDefinitionResponse, AgentDefinitionSummary
+from features.agent_definitions.service import AgentDefinitionService
+
+
+@pytest.mark.unit
+def test_agent_definition_model_fields() -> None:
+    """Verify model has expected domain fields."""
+    assert hasattr(AgentDefinition, "name")
+    assert hasattr(AgentDefinition, "role_template_id")
+    assert hasattr(AgentDefinition, "model_override")
+    assert hasattr(AgentDefinition, "mission")
+    assert hasattr(AgentDefinition, "background")
+    assert hasattr(AgentDefinition, "awareness")
+    assert hasattr(AgentDefinition, "is_active")
+
+
+@pytest.mark.unit
+def test_agent_definition_pattern_config() -> None:
+    """Verify Pattern inner class is configured correctly."""
+    assert AgentDefinition.Pattern.entity == "agent_definition"
+    assert AgentDefinition.Pattern.reference_prefix == "AGNT"
+    assert AgentDefinition.Pattern.track_changes is True
+
+
+@pytest.mark.unit
+def test_agent_definition_create_schema_defaults() -> None:
+    """Verify default values via create schema."""
+    data = AgentDefinitionCreate(
+        name="defaults-test",
+        role_template_id=uuid4(),
+        mission="Test mission",
+    )
+    assert data.is_active is True
+    assert data.awareness == {}
+
+
+@pytest.mark.unit
+def test_agent_definition_create_schema() -> None:
+    """Verify create schema with minimal data."""
+    role_id = uuid4()
+    data = AgentDefinitionCreate(
+        name="test-agent",
+        role_template_id=role_id,
+        mission="Test mission",
+    )
+    assert data.name == "test-agent"
+    assert data.role_template_id == role_id
+    assert data.mission == "Test mission"
+    assert data.is_active is True
+    assert data.awareness == {}
+
+
+@pytest.mark.unit
+def test_agent_definition_create_schema_full() -> None:
+    """Verify create schema with all fields."""
+    role_id = uuid4()
+    data = AgentDefinitionCreate(
+        name="test-agent",
+        role_template_id=role_id,
+        model_override="claude-opus-4-20250514",
+        mission="Test mission",
+        background="Expert developer.",
+        awareness={"key": "value"},
+        is_active=False,
+    )
+    assert data.name == "test-agent"
+    assert data.model_override == "claude-opus-4-20250514"
+    assert data.background == "Expert developer."
+    assert data.awareness == {"key": "value"}
+    assert data.is_active is False
+
+
+@pytest.mark.unit
+def test_agent_definition_create_requires_name() -> None:
+    """Verify name is required."""
+    with pytest.raises(ValidationError):
+        AgentDefinitionCreate(role_template_id=uuid4(), mission="Test")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_agent_definition_create_requires_role_template_id() -> None:
+    """Verify role_template_id is required."""
+    with pytest.raises(ValidationError):
+        AgentDefinitionCreate(name="test", mission="Test")  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_agent_definition_create_requires_mission() -> None:
+    """Verify mission is required."""
+    with pytest.raises(ValidationError):
+        AgentDefinitionCreate(name="test", role_template_id=uuid4())  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_agent_definition_create_rejects_empty_name() -> None:
+    """Verify empty name is rejected."""
+    with pytest.raises(ValidationError):
+        AgentDefinitionCreate(name="", role_template_id=uuid4(), mission="Test")
+
+
+@pytest.mark.unit
+def test_agent_definition_create_rejects_empty_mission() -> None:
+    """Verify empty mission is rejected."""
+    with pytest.raises(ValidationError):
+        AgentDefinitionCreate(name="test", role_template_id=uuid4(), mission="")
+
+
+@pytest.mark.unit
+def test_agent_definition_update_schema() -> None:
+    """Verify update schema allows partial updates."""
+    data = AgentDefinitionUpdate(is_active=False)
+    assert data.is_active is False
+    assert data.name is None
+    assert data.mission is None
+
+
+@pytest.mark.unit
+def test_agent_definition_response_schema() -> None:
+    """Verify response schema from_attributes config."""
+    assert AgentDefinitionResponse.model_config.get("from_attributes") is True
+
+
+@pytest.mark.unit
+def test_agent_definition_summary_schema() -> None:
+    """Verify summary schema from_attributes config."""
+    assert AgentDefinitionSummary.model_config.get("from_attributes") is True
+
+
+@pytest.mark.unit
+def test_agent_definition_service_model() -> None:
+    """Verify service is configured with correct model."""
+    service = AgentDefinitionService()
+    assert service.model is AgentDefinition

--- a/backend/tests/features/test_role_templates.py
+++ b/backend/tests/features/test_role_templates.py
@@ -1,0 +1,117 @@
+import pytest
+from pydantic import ValidationError
+
+from features.role_templates.models import RoleTemplate
+from features.role_templates.schemas.input import RoleTemplateCreate, RoleTemplateUpdate
+from features.role_templates.schemas.output import RoleTemplateResponse, RoleTemplateSummary
+from features.role_templates.service import RoleTemplateService
+
+
+@pytest.mark.unit
+def test_role_template_model_fields() -> None:
+    """Verify model has expected domain fields."""
+    assert hasattr(RoleTemplate, "name")
+    assert hasattr(RoleTemplate, "source")
+    assert hasattr(RoleTemplate, "archetype")
+    assert hasattr(RoleTemplate, "default_model")
+    assert hasattr(RoleTemplate, "persona")
+    assert hasattr(RoleTemplate, "judgments")
+    assert hasattr(RoleTemplate, "responsibilities")
+    assert hasattr(RoleTemplate, "description")
+    assert hasattr(RoleTemplate, "is_active")
+
+
+@pytest.mark.unit
+def test_role_template_pattern_config() -> None:
+    """Verify Pattern inner class is configured correctly."""
+    assert RoleTemplate.Pattern.entity == "role_template"
+    assert RoleTemplate.Pattern.reference_prefix == "ROLE"
+    assert RoleTemplate.Pattern.track_changes is True
+
+
+@pytest.mark.unit
+def test_role_template_create_schema_defaults() -> None:
+    """Verify default values via create schema."""
+    data = RoleTemplateCreate(name="defaults-test")
+    assert data.source == "custom"
+    assert data.is_active is True
+    assert data.persona == {}
+    assert data.judgments == []
+    assert data.responsibilities == []
+
+
+@pytest.mark.unit
+def test_role_template_create_schema() -> None:
+    """Verify create schema with minimal data."""
+    data = RoleTemplateCreate(name="test-role")
+    assert data.name == "test-role"
+    assert data.source == "custom"
+    assert data.persona == {}
+    assert data.judgments == []
+    assert data.responsibilities == []
+    assert data.is_active is True
+
+
+@pytest.mark.unit
+def test_role_template_create_schema_full() -> None:
+    """Verify create schema with all fields."""
+    data = RoleTemplateCreate(
+        name="test-role",
+        source="library",
+        archetype="Analyst",
+        default_model="claude-sonnet-4-20250514",
+        persona={"traits": ["analytical"]},
+        judgments=["judgment-1"],
+        responsibilities=["resp-1"],
+        description="A test role.",
+        is_active=False,
+    )
+    assert data.name == "test-role"
+    assert data.source == "library"
+    assert data.archetype == "Analyst"
+    assert data.persona == {"traits": ["analytical"]}
+    assert data.judgments == ["judgment-1"]
+    assert data.responsibilities == ["resp-1"]
+    assert data.is_active is False
+
+
+@pytest.mark.unit
+def test_role_template_create_requires_name() -> None:
+    """Verify name is required."""
+    with pytest.raises(ValidationError):
+        RoleTemplateCreate()  # type: ignore[call-arg]
+
+
+@pytest.mark.unit
+def test_role_template_create_rejects_empty_name() -> None:
+    """Verify empty name is rejected."""
+    with pytest.raises(ValidationError):
+        RoleTemplateCreate(name="")
+
+
+@pytest.mark.unit
+def test_role_template_update_schema() -> None:
+    """Verify update schema allows partial updates."""
+    data = RoleTemplateUpdate(is_active=False)
+    assert data.is_active is False
+    assert data.name is None
+    assert data.source is None
+
+
+@pytest.mark.unit
+def test_role_template_response_schema() -> None:
+    """Verify response schema from_attributes config."""
+    assert RoleTemplateResponse.model_config.get("from_attributes") is True
+
+
+@pytest.mark.unit
+def test_role_template_summary_schema() -> None:
+    """Verify summary schema from_attributes config."""
+    assert RoleTemplateSummary.model_config.get("from_attributes") is True
+
+
+@pytest.mark.unit
+def test_role_template_service_model() -> None:
+    """Verify service is configured with correct model."""
+    service = RoleTemplateService()
+    assert service.model is RoleTemplate

--- a/backend/tests/features/test_seed_data.py
+++ b/backend/tests/features/test_seed_data.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.unit
+def test_seed_yaml_loadable() -> None:
+    """Verify seed YAML loads with expected structure."""
+    seed_path = Path(__file__).parent.parent.parent / "seeds" / "agents.yaml"
+    with open(seed_path) as f:
+        data = yaml.safe_load(f)
+    assert len(data["role_templates"]) == 5
+    assert len(data["agent_definitions"]) == 5
+    names = {rt["name"] for rt in data["role_templates"]}
+    assert names == {"understander", "planner", "specifier", "implementer", "reviewer"}
+
+
+@pytest.mark.unit
+def test_seed_agent_definitions_reference_valid_roles() -> None:
+    """Verify each agent definition references an existing role template."""
+    seed_path = Path(__file__).parent.parent.parent / "seeds" / "agents.yaml"
+    with open(seed_path) as f:
+        data = yaml.safe_load(f)
+    role_names = {rt["name"] for rt in data["role_templates"]}
+    for ad in data["agent_definitions"]:
+        assert ad["role_template"] in role_names, (
+            f"Agent '{ad['name']}' references unknown role '{ad['role_template']}'"
+        )
+
+
+@pytest.mark.unit
+def test_seed_role_templates_have_required_fields() -> None:
+    """Verify each role template has required fields."""
+    seed_path = Path(__file__).parent.parent.parent / "seeds" / "agents.yaml"
+    with open(seed_path) as f:
+        data = yaml.safe_load(f)
+    for rt in data["role_templates"]:
+        assert "name" in rt
+        assert "source" in rt
+        assert "responsibilities" in rt
+        assert len(rt["responsibilities"]) > 0
+
+
+@pytest.mark.unit
+def test_seed_agent_definitions_have_required_fields() -> None:
+    """Verify each agent definition has required fields."""
+    seed_path = Path(__file__).parent.parent.parent / "seeds" / "agents.yaml"
+    with open(seed_path) as f:
+        data = yaml.safe_load(f)
+    for ad in data["agent_definitions"]:
+        assert "name" in ad
+        assert "role_template" in ad
+        assert "mission" in ad
+        assert len(ad["mission"]) > 0


### PR DESCRIPTION
## Summary
- 2 pattern-stack features: RoleTemplate and AgentDefinition
- RoleTemplate stores persona, judgments, responsibilities as JSON fields
- AgentDefinition links to RoleTemplate with model override and mission config
- Custom service queries: `get_by_name()`, `list_active()`
- Pydantic schemas and unit tests

## Stack: sb-ep001 (3/7)
Stacked on: SB-002 (conversation domain)

## Test plan
- [x] RoleTemplateService.get_by_name() works
- [x] AgentDefinitionService.list_active() filters correctly
- [x] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)