### PR TITLE
Shell

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import { StackSidebar } from "@/components/organisms";
+import { AppShell } from "@/components/templates";
 import { useStackDetail } from "@/hooks/useStackDetail";
 import type { StackConnectorItem } from "@/components/molecules";
+import type { TabItem } from "@/components/molecules/TabBar";
 
 function branchTitle(name: string): string {
-  // Extract the last segment: "dug/frontend-mvp/3-stack-nav" → "3-stack-nav"
   const parts = name.split("/");
   return parts[parts.length - 1] ?? name;
 }
@@ -18,7 +18,8 @@ const mockDiffStats: Record<string, { additions: number; deletions: number }> = 
 
 export function App() {
   const { data, loading, error } = useStackDetail();
-  const [activeIndex, setActiveIndex] = useState(2); // Default to 3rd branch (current work)
+  const [activeIndex, setActiveIndex] = useState(2);
+  const [activeTab, setActiveTab] = useState("files");
 
   if (loading) {
     return (
@@ -37,7 +38,6 @@ export function App() {
   }
 
   const items: StackConnectorItem[] = data.branches.map((b) => {
-    // Determine the display status: prefer PR state over branch state
     const displayStatus = b.pull_request?.state ?? b.branch.state;
     const stats = mockDiffStats[b.branch.id] ?? { additions: 0, deletions: 0 };
 
@@ -50,21 +50,31 @@ export function App() {
     };
   });
 
+  const activeBranch = data.branches[activeIndex] ?? null;
+
+  const activeStats = mockDiffStats[activeBranch?.branch.id ?? ""];
+  const fileCount = activeStats && (activeStats.additions > 0 || activeStats.deletions > 0)
+    ? Math.ceil((activeStats.additions + activeStats.deletions) / 20)
+    : 0;
+
+  const tabs: TabItem[] = [
+    { id: "files", label: "Files changed", count: fileCount || undefined },
+  ];
+
   return (
-    <div className="flex h-screen bg-[var(--bg-canvas)] text-[var(--fg-default)] font-[family-name:var(--font-sans)]">
-      <StackSidebar
-        stackName={data.stack.name}
-        trunk={data.stack.trunk}
-        items={items}
-        activeIndex={activeIndex}
-        onSelect={setActiveIndex}
-      />
-      {/* Main content area — placeholder until SB-038 (App Shell) */}
-      <main className="flex-1 flex items-center justify-center">
-        <div className="text-center space-y-4">
-          <h1 className="text-2xl font-semibold tracking-tight">
-            {items[activeIndex]?.title ?? "Select a branch"}
-          </h1>
+    <AppShell
+      stackName={data.stack.name}
+      trunk={data.stack.trunk}
+      items={items}
+      activeIndex={activeIndex}
+      onSelect={setActiveIndex}
+      activeBranch={activeBranch}
+      tabs={tabs}
+      activeTab={activeTab}
+      onTabChange={setActiveTab}
+    >
+      <div className="flex items-center justify-center h-full">
+        <div className="text-center space-y-3">
           <p className="text-[var(--fg-muted)] text-sm">
             Diff review panel will render here (SB-039).
           </p>
@@ -72,7 +82,7 @@ export function App() {
             v0.0.1 &middot; Stack Bench
           </p>
         </div>
-      </main>
-    </div>
+      </div>
+    </AppShell>
   );
 }

--- a/app/frontend/src/components/atoms/BranchMeta/BranchMeta.tsx
+++ b/app/frontend/src/components/atoms/BranchMeta/BranchMeta.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+interface BranchMetaProps {
+  base: string;
+  head: string;
+  className?: string;
+}
+
+function BranchMeta({ base, head, className }: BranchMetaProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 font-[family-name:var(--font-mono)] text-xs text-[var(--fg-muted)]",
+        className
+      )}
+    >
+      <span>{base}</span>
+      <span className="text-[var(--accent)]">&larr;</span>
+      <span>{head}</span>
+    </span>
+  );
+}
+
+BranchMeta.displayName = "BranchMeta";
+
+export { BranchMeta };
+export type { BranchMetaProps };

--- a/app/frontend/src/components/atoms/BranchMeta/index.ts
+++ b/app/frontend/src/components/atoms/BranchMeta/index.ts
@@ -1,0 +1,2 @@
+export { BranchMeta } from "./BranchMeta";
+export type { BranchMetaProps } from "./BranchMeta";

--- a/app/frontend/src/components/atoms/index.ts
+++ b/app/frontend/src/components/atoms/index.ts
@@ -23,3 +23,6 @@ export type { StackDotProps, StackDotColor } from "./StackDot";
 
 export { DiffStat } from "./DiffStat";
 export type { DiffStatProps } from "./DiffStat";
+
+export { BranchMeta } from "./BranchMeta";
+export type { BranchMetaProps } from "./BranchMeta";

--- a/app/frontend/src/components/molecules/ActionBar/ActionBar.tsx
+++ b/app/frontend/src/components/molecules/ActionBar/ActionBar.tsx
@@ -1,0 +1,33 @@
+import { Button } from "@/components/atoms";
+import { StatusBadge } from "@/components/molecules/StatusBadge";
+
+interface ActionBarProps {
+  status: string;
+  onPush?: () => void;
+}
+
+function ActionBar({ status, onPush }: ActionBarProps) {
+  return (
+    <div className="flex items-center justify-between px-6 py-3 bg-[var(--bg-surface)] border-t border-[var(--border)]">
+      <div className="flex items-center gap-2">
+        <StatusBadge status={status} />
+        <span className="text-xs text-[var(--fg-muted)]">
+          {status === "created" ? "Not yet pushed" : `Status: ${status}`}
+        </span>
+      </div>
+      <Button
+        variant="primary"
+        size="sm"
+        onClick={onPush}
+        disabled={!onPush}
+      >
+        Mark ready &amp; push
+      </Button>
+    </div>
+  );
+}
+
+ActionBar.displayName = "ActionBar";
+
+export { ActionBar };
+export type { ActionBarProps };

--- a/app/frontend/src/components/molecules/ActionBar/index.ts
+++ b/app/frontend/src/components/molecules/ActionBar/index.ts
@@ -1,0 +1,2 @@
+export { ActionBar } from "./ActionBar";
+export type { ActionBarProps } from "./ActionBar";

--- a/app/frontend/src/components/molecules/PRHeader/PRHeader.tsx
+++ b/app/frontend/src/components/molecules/PRHeader/PRHeader.tsx
@@ -1,0 +1,31 @@
+import { BranchMeta } from "@/components/atoms/BranchMeta";
+
+interface PRHeaderProps {
+  title: string;
+  baseBranch: string;
+  headBranch: string;
+  description?: string | null;
+}
+
+function PRHeader({ title, baseBranch, headBranch, description }: PRHeaderProps) {
+  return (
+    <div className="px-6 py-5 bg-[var(--bg-surface)] border-b border-[var(--border)]">
+      <h2 className="text-xl font-semibold text-[var(--fg-default)] leading-tight">
+        {title}
+      </h2>
+      <div className="mt-2">
+        <BranchMeta base={baseBranch} head={headBranch} />
+      </div>
+      {description && (
+        <p className="mt-3 text-sm text-[var(--fg-muted)] leading-relaxed">
+          {description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+PRHeader.displayName = "PRHeader";
+
+export { PRHeader };
+export type { PRHeaderProps };

--- a/app/frontend/src/components/molecules/PRHeader/index.ts
+++ b/app/frontend/src/components/molecules/PRHeader/index.ts
@@ -1,0 +1,2 @@
+export { PRHeader } from "./PRHeader";
+export type { PRHeaderProps } from "./PRHeader";

--- a/app/frontend/src/components/molecules/TabBar/TabBar.tsx
+++ b/app/frontend/src/components/molecules/TabBar/TabBar.tsx
@@ -1,0 +1,40 @@
+import { Tab, CountBadge } from "@/components/atoms";
+
+interface TabItem {
+  id: string;
+  label: string;
+  count?: number;
+}
+
+interface TabBarProps {
+  tabs: TabItem[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+}
+
+function TabBar({ tabs, activeTab, onTabChange }: TabBarProps) {
+  return (
+    <div
+      className="flex items-end gap-0 px-6 bg-[var(--bg-surface)] border-b border-[var(--border)]"
+      role="tablist"
+    >
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.id}
+          active={tab.id === activeTab}
+          onClick={() => onTabChange(tab.id)}
+        >
+          {tab.label}
+          {tab.count !== undefined && (
+            <CountBadge count={tab.count} />
+          )}
+        </Tab>
+      ))}
+    </div>
+  );
+}
+
+TabBar.displayName = "TabBar";
+
+export { TabBar };
+export type { TabBarProps, TabItem };

--- a/app/frontend/src/components/molecules/TabBar/index.ts
+++ b/app/frontend/src/components/molecules/TabBar/index.ts
@@ -1,0 +1,2 @@
+export { TabBar } from "./TabBar";
+export type { TabBarProps, TabItem } from "./TabBar";

--- a/app/frontend/src/components/molecules/index.ts
+++ b/app/frontend/src/components/molecules/index.ts
@@ -6,3 +6,12 @@ export type { StackItemProps } from "./StackItem";
 
 export { StackConnector } from "./StackConnector";
 export type { StackConnectorProps, StackConnectorItem } from "./StackConnector";
+
+export { PRHeader } from "./PRHeader";
+export type { PRHeaderProps } from "./PRHeader";
+
+export { TabBar } from "./TabBar";
+export type { TabBarProps, TabItem } from "./TabBar";
+
+export { ActionBar } from "./ActionBar";
+export type { ActionBarProps } from "./ActionBar";

--- a/app/frontend/src/components/templates/AppShell/AppShell.tsx
+++ b/app/frontend/src/components/templates/AppShell/AppShell.tsx
@@ -1,0 +1,91 @@
+import type { ReactNode } from "react";
+import { StackSidebar } from "@/components/organisms/StackSidebar";
+import { PRHeader } from "@/components/molecules/PRHeader";
+import { TabBar } from "@/components/molecules/TabBar";
+import type { TabItem } from "@/components/molecules/TabBar";
+import { ActionBar } from "@/components/molecules/ActionBar";
+import type { StackConnectorItem } from "@/components/molecules/StackConnector";
+import type { BranchWithPR } from "@/types/stack";
+
+interface AppShellProps {
+  stackName: string;
+  trunk: string;
+  items: StackConnectorItem[];
+  activeIndex: number;
+  onSelect: (index: number) => void;
+  activeBranch: BranchWithPR | null;
+  tabs: TabItem[];
+  activeTab: string;
+  onTabChange: (tabId: string) => void;
+  children?: ReactNode;
+}
+
+/** Extract short branch name from full ref: "dug/frontend-mvp/3-stack-nav" → "3-stack-nav" */
+function shortBranch(name: string): string {
+  const parts = name.split("/");
+  return parts[parts.length - 1] ?? name;
+}
+
+function AppShell({
+  stackName,
+  trunk,
+  items,
+  activeIndex,
+  onSelect,
+  activeBranch,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+}: AppShellProps) {
+  // Derive PRHeader props from the active branch
+  const pr = activeBranch?.pull_request;
+  const branchName = activeBranch?.branch.name ?? "";
+  const title = pr?.title ?? shortBranch(branchName);
+  const description = pr?.description ?? (pr ? null : "No pull request");
+  const headBranch = shortBranch(branchName);
+
+  // Base branch: for position 1, base is trunk. For others, it's the previous branch.
+  const position = activeBranch?.branch.position ?? 1;
+  const baseBranch = position <= 1 ? trunk : shortBranch(
+    // Find branch at position - 1
+    items[activeIndex - 1]?.title ?? trunk
+  );
+
+  // Display status: prefer PR state over branch state
+  const displayStatus = pr?.state ?? activeBranch?.branch.state ?? "created";
+
+  return (
+    <div className="flex h-screen bg-[var(--bg-canvas)] text-[var(--fg-default)] font-[family-name:var(--font-sans)]">
+      <StackSidebar
+        stackName={stackName}
+        trunk={trunk}
+        items={items}
+        activeIndex={activeIndex}
+        onSelect={onSelect}
+      />
+      <main className="flex-1 flex flex-col min-w-0">
+        <PRHeader
+          title={title}
+          baseBranch={baseBranch}
+          headBranch={headBranch}
+          description={description}
+        />
+        <TabBar
+          tabs={tabs}
+          activeTab={activeTab}
+          onTabChange={onTabChange}
+        />
+        <div className="flex-1 overflow-auto">
+          {children}
+        </div>
+        <ActionBar status={displayStatus} />
+      </main>
+    </div>
+  );
+}
+
+AppShell.displayName = "AppShell";
+
+export { AppShell };
+export type { AppShellProps };

--- a/app/frontend/src/components/templates/AppShell/index.ts
+++ b/app/frontend/src/components/templates/AppShell/index.ts
@@ -1,0 +1,2 @@
+export { AppShell } from "./AppShell";
+export type { AppShellProps } from "./AppShell";

--- a/app/frontend/src/components/templates/index.ts
+++ b/app/frontend/src/components/templates/index.ts
@@ -1,0 +1,2 @@
+export { AppShell } from "./AppShell";
+export type { AppShellProps } from "./AppShell";


### PR DESCRIPTION
## Summary
Introduces the `AppShell` template component to replace the bare layout placeholder, composing the sidebar with a PR header, tab bar, and action bar into a complete page shell.

## Changes
- Add `AppShell` template that wires `StackSidebar`, `PRHeader`, `TabBar`, and `ActionBar` into a cohesive layout
- Add `PRHeader` molecule displaying PR title, base→head branch meta, and optional description
- Add `TabBar` molecule with count badge support for tab navigation
- Add `ActionBar` molecule with status display and a "Mark ready & push" CTA
- Add `BranchMeta` atom for rendering the base←head branch reference in monospace

---
**Stack:** `frontend-mvp` (PR 4 of 6)
*Generated with [Claude Code](https://claude.com/claude-code)*