### PR TITLE
Explorer Polish

### DIFF
--- a/app/frontend/src/components/atoms/FileIcon/FileIcon.tsx
+++ b/app/frontend/src/components/atoms/FileIcon/FileIcon.tsx
@@ -1,13 +1,35 @@
 import { Icon } from "@/components/atoms/Icon";
 import { cn } from "@/lib/utils";
 
+const extensionColors: Record<string, string> = {
+  tsx: "var(--accent)",
+  jsx: "var(--accent)",
+  ts: "var(--yellow)",
+  js: "var(--yellow)",
+  css: "var(--purple)",
+  scss: "var(--purple)",
+  json: "var(--yellow)",
+  md: "var(--fg-muted)",
+  html: "var(--red)",
+  go: "var(--accent)",
+  py: "var(--yellow)",
+};
+
+function getExtensionColor(fileName?: string): string {
+  if (!fileName) return "var(--fg-subtle)";
+  const ext = fileName.split(".").pop()?.toLowerCase();
+  if (!ext) return "var(--fg-subtle)";
+  return extensionColors[ext] ?? "var(--fg-subtle)";
+}
+
 interface FileIconProps {
   type: "file" | "dir";
   isOpen?: boolean;
+  fileName?: string;
   className?: string;
 }
 
-function FileIcon({ type, isOpen = false, className }: FileIconProps) {
+function FileIcon({ type, isOpen = false, fileName, className }: FileIconProps) {
   if (type === "dir") {
     return (
       <span className={cn("inline-flex items-center", className)}>
@@ -25,12 +47,15 @@ function FileIcon({ type, isOpen = false, className }: FileIconProps) {
     );
   }
 
+  const color = getExtensionColor(fileName);
+
   return (
     <span className={cn("inline-flex items-center", className)}>
       <Icon
         name="file"
         size="sm"
-        className="text-[var(--fg-subtle)] ml-[14px]"
+        className="ml-[14px]"
+        style={{ color }}
       />
     </span>
   );
@@ -38,5 +63,5 @@ function FileIcon({ type, isOpen = false, className }: FileIconProps) {
 
 FileIcon.displayName = "FileIcon";
 
-export { FileIcon };
+export { FileIcon, extensionColors, getExtensionColor };
 export type { FileIconProps };

--- a/app/frontend/src/components/atoms/FileIcon/index.ts
+++ b/app/frontend/src/components/atoms/FileIcon/index.ts
@@ -1,2 +1,2 @@
-export { FileIcon } from "./FileIcon";
+export { FileIcon, extensionColors, getExtensionColor } from "./FileIcon";
 export type { FileIconProps } from "./FileIcon";

--- a/app/frontend/src/components/atoms/Icon/Icon.tsx
+++ b/app/frontend/src/components/atoms/Icon/Icon.tsx
@@ -53,6 +53,38 @@ const iconPaths: Record<string, React.ReactNode> = {
   "message-square": (
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
   ),
+  search: (
+    <>
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </>
+  ),
+  "x-circle": (
+    <>
+      <circle cx="12" cy="12" r="10" />
+      <line x1="15" y1="9" x2="9" y2="15" />
+      <line x1="9" y1="9" x2="15" y2="15" />
+    </>
+  ),
+  "collapse-all": (
+    <>
+      <polyline points="15 4 9 10 15 16" />
+      <polyline points="19 4 13 10 19 16" />
+    </>
+  ),
+  "expand-all": (
+    <>
+      <polyline points="4 9 10 15 16 9" />
+      <polyline points="4 5 10 11 16 5" />
+    </>
+  ),
+  "refresh-cw": (
+    <>
+      <polyline points="23 4 23 10 17 10" />
+      <polyline points="1 20 1 14 7 14" />
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+    </>
+  ),
 };
 
 type IconName = keyof typeof iconPaths;

--- a/app/frontend/src/components/atoms/IndentGuide/IndentGuide.tsx
+++ b/app/frontend/src/components/atoms/IndentGuide/IndentGuide.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+
+interface IndentGuideProps {
+  depth: number;
+  className?: string;
+}
+
+function IndentGuide({ depth, className }: IndentGuideProps) {
+  if (depth <= 0) return null;
+
+  return (
+    <span className={cn("absolute inset-y-0 left-0 pointer-events-none", className)}>
+      {Array.from({ length: depth }, (_, i) => (
+        <span
+          key={i}
+          className="absolute top-0 bottom-0 w-px bg-[var(--indent-guide)]"
+          style={{ left: `${i * 12 + 8}px` }}
+        />
+      ))}
+    </span>
+  );
+}
+
+IndentGuide.displayName = "IndentGuide";
+
+export { IndentGuide };
+export type { IndentGuideProps };

--- a/app/frontend/src/components/atoms/IndentGuide/index.ts
+++ b/app/frontend/src/components/atoms/IndentGuide/index.ts
@@ -1,0 +1,2 @@
+export { IndentGuide } from "./IndentGuide";
+export type { IndentGuideProps } from "./IndentGuide";

--- a/app/frontend/src/components/atoms/SearchInput/SearchInput.tsx
+++ b/app/frontend/src/components/atoms/SearchInput/SearchInput.tsx
@@ -1,0 +1,50 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { Icon } from "@/components/atoms/Icon";
+import { cn } from "@/lib/utils";
+
+interface SearchInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  onClear?: () => void;
+}
+
+const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
+  ({ className, value, onClear, ...props }, ref) => {
+    const hasValue = value !== undefined && value !== "";
+
+    return (
+      <div className={cn("relative flex items-center", className)}>
+        <Icon
+          name="search"
+          size="xs"
+          className="absolute left-2 text-[var(--fg-subtle)] pointer-events-none"
+        />
+        <input
+          ref={ref}
+          type="text"
+          value={value}
+          className={cn(
+            "w-full h-7 pl-7 pr-7 text-xs rounded",
+            "bg-[var(--bg-inset)] border border-[var(--border-muted)]",
+            "text-[var(--fg-default)] placeholder:text-[var(--fg-subtle)]",
+            "focus:outline-none focus:border-[var(--accent)] focus:ring-1 focus:ring-[var(--accent)]",
+            "transition-colors"
+          )}
+          {...props}
+        />
+        {hasValue && onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="absolute right-1.5 p-0.5 rounded hover:bg-[var(--bg-surface-hover)] text-[var(--fg-subtle)] hover:text-[var(--fg-muted)] transition-colors"
+          >
+            <Icon name="x-circle" size="xs" />
+          </button>
+        )}
+      </div>
+    );
+  }
+);
+
+SearchInput.displayName = "SearchInput";
+
+export { SearchInput };
+export type { SearchInputProps };

--- a/app/frontend/src/components/atoms/SearchInput/index.ts
+++ b/app/frontend/src/components/atoms/SearchInput/index.ts
@@ -1,0 +1,2 @@
+export { SearchInput } from "./SearchInput";
+export type { SearchInputProps } from "./SearchInput";

--- a/app/frontend/src/components/molecules/ExplorerToolbar/ExplorerToolbar.tsx
+++ b/app/frontend/src/components/molecules/ExplorerToolbar/ExplorerToolbar.tsx
@@ -1,0 +1,60 @@
+import { Icon } from "@/components/atoms/Icon";
+import type { IconName } from "@/components/atoms/Icon";
+import { cn } from "@/lib/utils";
+
+interface ExplorerToolbarProps {
+  title?: string;
+  onCollapseAll: () => void;
+  onExpandAll: () => void;
+  onRefresh: () => void;
+}
+
+function ToolbarButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: IconName;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      className={cn(
+        "flex items-center justify-center w-6 h-6 rounded",
+        "text-[var(--fg-muted)] hover:text-[var(--fg-default)]",
+        "hover:bg-[var(--bg-surface-hover)] transition-colors"
+      )}
+    >
+      <Icon name={icon} size="sm" />
+    </button>
+  );
+}
+
+function ExplorerToolbar({
+  title = "EXPLORER",
+  onCollapseAll,
+  onExpandAll,
+  onRefresh,
+}: ExplorerToolbarProps) {
+  return (
+    <div className="flex items-center justify-between px-3 py-1.5 border-b border-[var(--border-muted)]">
+      <span className="text-[11px] font-semibold tracking-wider uppercase text-[var(--fg-muted)] select-none">
+        {title}
+      </span>
+      <div className="flex items-center gap-0.5">
+        <ToolbarButton icon="collapse-all" label="Collapse All" onClick={onCollapseAll} />
+        <ToolbarButton icon="expand-all" label="Expand All" onClick={onExpandAll} />
+        <ToolbarButton icon="refresh-cw" label="Refresh" onClick={onRefresh} />
+      </div>
+    </div>
+  );
+}
+
+ExplorerToolbar.displayName = "ExplorerToolbar";
+
+export { ExplorerToolbar };
+export type { ExplorerToolbarProps };

--- a/app/frontend/src/components/molecules/ExplorerToolbar/index.ts
+++ b/app/frontend/src/components/molecules/ExplorerToolbar/index.ts
@@ -1,0 +1,2 @@
+export { ExplorerToolbar } from "./ExplorerToolbar";
+export type { ExplorerToolbarProps } from "./ExplorerToolbar";

--- a/app/frontend/src/components/molecules/FileContent/FileContent.tsx
+++ b/app/frontend/src/components/molecules/FileContent/FileContent.tsx
@@ -12,11 +12,6 @@ function FileContent({ file }: FileContentProps) {
 
   return (
     <div className="flex flex-col h-full">
-      {/* File path breadcrumb */}
-      <div className="px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-surface)] text-xs font-[family-name:var(--font-mono)] text-[var(--fg-muted)]">
-        {file.path}
-      </div>
-
       {/* File content */}
       <div className="flex-1 overflow-auto">
         <table className="w-full border-collapse">

--- a/app/frontend/src/components/molecules/FileTreeItem/FileTreeItem.tsx
+++ b/app/frontend/src/components/molecules/FileTreeItem/FileTreeItem.tsx
@@ -1,4 +1,5 @@
 import { FileIcon } from "@/components/atoms/FileIcon";
+import { IndentGuide } from "@/components/atoms/IndentGuide";
 import { cn } from "@/lib/utils";
 
 interface FileTreeItemProps {
@@ -7,7 +8,23 @@ interface FileTreeItemProps {
   depth: number;
   isOpen?: boolean;
   isActive?: boolean;
+  highlight?: string;
   onClick: () => void;
+}
+
+function highlightMatch(text: string, query: string): React.ReactNode {
+  if (!query) return text;
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-[var(--accent-muted)] text-inherit rounded-sm px-px">
+        {text.slice(idx, idx + query.length)}
+      </mark>
+      {text.slice(idx + query.length)}
+    </>
+  );
 }
 
 function FileTreeItem({
@@ -16,6 +33,7 @@ function FileTreeItem({
   depth,
   isOpen = false,
   isActive = false,
+  highlight,
   onClick,
 }: FileTreeItemProps) {
   return (
@@ -23,7 +41,7 @@ function FileTreeItem({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex items-center w-full gap-1.5 py-0.5 px-2 text-sm text-left rounded",
+        "relative flex items-center w-full gap-1.5 py-0.5 pr-2 text-sm text-left rounded group",
         "text-[13px]",
         "hover:bg-[var(--bg-surface-hover)] transition-colors",
         isActive && "bg-[var(--accent-muted)] text-[var(--accent)]",
@@ -31,8 +49,11 @@ function FileTreeItem({
       )}
       style={{ paddingLeft: `${depth * 12 + 8}px` }}
     >
-      <FileIcon type={type} isOpen={isOpen} />
-      <span className="truncate">{name}</span>
+      <IndentGuide depth={depth} />
+      <FileIcon type={type} isOpen={isOpen} fileName={name} />
+      <span className="truncate">
+        {highlight ? highlightMatch(name, highlight) : name}
+      </span>
     </button>
   );
 }

--- a/app/frontend/src/components/molecules/PathBar/PathBar.tsx
+++ b/app/frontend/src/components/molecules/PathBar/PathBar.tsx
@@ -1,0 +1,50 @@
+import { Icon } from "@/components/atoms/Icon";
+import { getExtensionColor } from "@/components/atoms/FileIcon";
+import { cn } from "@/lib/utils";
+
+interface PathBarProps {
+  path: string;
+  onNavigate?: (segmentPath: string) => void;
+}
+
+function PathBar({ path, onNavigate }: PathBarProps) {
+  const segments = path.split("/").filter(Boolean);
+
+  return (
+    <div className="flex items-center gap-1 px-4 py-2 border-b border-[var(--border)] bg-[var(--bg-surface)] text-xs font-[family-name:var(--font-mono)] overflow-x-auto">
+      {segments.map((segment, i) => {
+        const isLast = i === segments.length - 1;
+        const segmentPath = segments.slice(0, i + 1).join("/");
+        const color = isLast ? getExtensionColor(segment) : undefined;
+
+        return (
+          <span key={segmentPath} className="flex items-center gap-1 shrink-0">
+            {i > 0 && (
+              <Icon
+                name="chevron-right"
+                size="xs"
+                className="text-[var(--fg-subtle)]"
+              />
+            )}
+            <button
+              type="button"
+              onClick={() => onNavigate?.(segmentPath)}
+              className={cn(
+                "hover:text-[var(--accent)] transition-colors rounded px-0.5",
+                isLast ? "font-semibold" : "text-[var(--fg-muted)]"
+              )}
+              style={isLast && color ? { color } : undefined}
+            >
+              {segment}
+            </button>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+PathBar.displayName = "PathBar";
+
+export { PathBar };
+export type { PathBarProps };

--- a/app/frontend/src/components/molecules/PathBar/index.ts
+++ b/app/frontend/src/components/molecules/PathBar/index.ts
@@ -1,0 +1,2 @@
+export { PathBar } from "./PathBar";
+export type { PathBarProps } from "./PathBar";

--- a/app/frontend/src/components/organisms/FileTree/FileTree.tsx
+++ b/app/frontend/src/components/organisms/FileTree/FileTree.tsx
@@ -1,11 +1,14 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { FileTreeItem } from "@/components/molecules/FileTreeItem";
+import { ExplorerToolbar } from "@/components/molecules/ExplorerToolbar";
+import { SearchInput } from "@/components/atoms/SearchInput";
 import type { FileTreeNode } from "@/types/file-tree";
 
 interface FileTreeProps {
   tree: FileTreeNode;
   selectedPath: string | null;
   onSelectFile: (path: string) => void;
+  onRefresh?: () => void;
 }
 
 function sortChildren(children: FileTreeNode[]): FileTreeNode[] {
@@ -15,9 +18,48 @@ function sortChildren(children: FileTreeNode[]): FileTreeNode[] {
   });
 }
 
-function FileTree({ tree, selectedPath, onSelectFile }: FileTreeProps) {
+function collectAllDirs(node: FileTreeNode): string[] {
+  const dirs: string[] = [];
+  if (node.type === "dir" && node.path !== "") {
+    dirs.push(node.path);
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      dirs.push(...collectAllDirs(child));
+    }
+  }
+  return dirs;
+}
+
+function collectMatchingPaths(
+  node: FileTreeNode,
+  query: string
+): Set<string> {
+  const matched = new Set<string>();
+  const lowerQuery = query.toLowerCase();
+
+  function walk(n: FileTreeNode, ancestors: string[]) {
+    const matches = n.path.toLowerCase().includes(lowerQuery);
+    if (matches && n.type === "file") {
+      matched.add(n.path);
+      for (const a of ancestors) matched.add(a);
+    }
+    if (n.children) {
+      const nextAncestors = n.type === "dir" && n.path !== ""
+        ? [...ancestors, n.path]
+        : ancestors;
+      for (const child of n.children) {
+        walk(child, nextAncestors);
+      }
+    }
+  }
+
+  walk(node, []);
+  return matched;
+}
+
+function FileTree({ tree, selectedPath, onSelectFile, onRefresh }: FileTreeProps) {
   const [expanded, setExpanded] = useState<Set<string>>(() => {
-    // Default: expand first level
     const initial = new Set<string>();
     if (tree.children) {
       for (const child of tree.children) {
@@ -28,6 +70,9 @@ function FileTree({ tree, selectedPath, onSelectFile }: FileTreeProps) {
     }
     return initial;
   });
+
+  const [filterText, setFilterText] = useState("");
+  const savedExpanded = useRef<Set<string> | null>(null);
 
   const toggleDir = useCallback((path: string) => {
     setExpanded((prev) => {
@@ -41,13 +86,59 @@ function FileTree({ tree, selectedPath, onSelectFile }: FileTreeProps) {
     });
   }, []);
 
+  const collapseAll = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  const expandAll = useCallback(() => {
+    setExpanded(new Set(collectAllDirs(tree)));
+  }, [tree]);
+
+  const handleFilterChange = useCallback(
+    (value: string) => {
+      if (value && !filterText) {
+        savedExpanded.current = new Set(expanded);
+      }
+      setFilterText(value);
+
+      if (value) {
+        const matched = collectMatchingPaths(tree, value);
+        const dirsToExpand = new Set<string>();
+        for (const p of matched) {
+          // Add parent dirs
+          const parts = p.split("/");
+          for (let i = 1; i < parts.length; i++) {
+            dirsToExpand.add(parts.slice(0, i).join("/"));
+          }
+        }
+        setExpanded(dirsToExpand);
+      } else if (savedExpanded.current) {
+        setExpanded(savedExpanded.current);
+        savedExpanded.current = null;
+      }
+    },
+    [filterText, expanded, tree]
+  );
+
+  const handleClearFilter = useCallback(() => {
+    handleFilterChange("");
+  }, [handleFilterChange]);
+
+  const matchedPaths = filterText
+    ? collectMatchingPaths(tree, filterText)
+    : null;
+
   const renderNode = (node: FileTreeNode, depth: number) => {
     const isDir = node.type === "dir";
     const isOpen = expanded.has(node.path);
 
+    // When filtering, hide non-matching nodes
+    if (matchedPaths && node.path !== "" && !matchedPaths.has(node.path)) {
+      return null;
+    }
+
     return (
       <div key={node.path || node.name}>
-        {/* Don't render the root "." node itself */}
         {node.path !== "" && (
           <FileTreeItem
             name={node.name}
@@ -55,6 +146,7 @@ function FileTree({ tree, selectedPath, onSelectFile }: FileTreeProps) {
             depth={depth}
             isOpen={isOpen}
             isActive={selectedPath === node.path}
+            highlight={filterText || undefined}
             onClick={() =>
               isDir ? toggleDir(node.path) : onSelectFile(node.path)
             }
@@ -72,8 +164,23 @@ function FileTree({ tree, selectedPath, onSelectFile }: FileTreeProps) {
   };
 
   return (
-    <div className="py-1 overflow-y-auto h-full">
-      {renderNode(tree, 0)}
+    <div className="flex flex-col h-full">
+      <ExplorerToolbar
+        onCollapseAll={collapseAll}
+        onExpandAll={expandAll}
+        onRefresh={onRefresh ?? (() => {})}
+      />
+      <div className="px-2 py-1.5">
+        <SearchInput
+          placeholder="Search files..."
+          value={filterText}
+          onChange={(e) => handleFilterChange(e.target.value)}
+          onClear={handleClearFilter}
+        />
+      </div>
+      <div className="flex-1 py-1 overflow-y-auto">
+        {renderNode(tree, 0)}
+      </div>
     </div>
   );
 }

--- a/app/frontend/src/components/organisms/FileViewerPanel/FileViewerPanel.tsx
+++ b/app/frontend/src/components/organisms/FileViewerPanel/FileViewerPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { FileTree } from "@/components/organisms/FileTree";
 import { FileContent } from "@/components/molecules/FileContent";
+import { PathBar } from "@/components/molecules/PathBar";
 import { useFileTree } from "@/hooks/useFileTree";
 import { useFileContent } from "@/hooks/useFileContent";
 
@@ -24,7 +25,7 @@ function FileViewerPanel({ branchId }: FileViewerPanelProps) {
   return (
     <div className="flex h-full">
       {/* File tree sidebar */}
-      <div className="w-[250px] shrink-0 border-r border-[var(--border)] bg-[var(--bg-surface)] overflow-hidden">
+      <div className="w-[250px] shrink-0 border-r border-[var(--border)] bg-[var(--bg-surface)] overflow-hidden flex flex-col">
         <FileTree
           tree={tree}
           selectedPath={selectedPath}
@@ -33,9 +34,14 @@ function FileViewerPanel({ branchId }: FileViewerPanelProps) {
       </div>
 
       {/* File content area */}
-      <div className="flex-1 min-w-0 overflow-hidden">
+      <div className="flex-1 min-w-0 overflow-hidden flex flex-col">
         {fileContent ? (
-          <FileContent file={fileContent} />
+          <>
+            <PathBar path={fileContent.path} />
+            <div className="flex-1 min-h-0 overflow-hidden">
+              <FileContent file={fileContent} />
+            </div>
+          </>
         ) : (
           <div className="flex items-center justify-center h-full">
             <p className="text-[var(--fg-muted)] text-sm">

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -36,6 +36,10 @@
   --red-bg: #28171a;             /* Diff deletion background */
   --accent-muted: #1f6feb33;     /* Selected/active background */
 
+  /* ── Indent Guides ─────────────────────────────────────── */
+  --indent-guide: #21262d;       /* Indent guide line color */
+  --indent-guide-active: #30363d; /* Indent guide on hover scope */
+
   /* ── Typography ──────────────────────────────────────────── */
   --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
## Summary
Upgrades the file explorer from a basic tree to a VS Code-style panel with search filtering, indent guides, breadcrumb navigation, and a toolbar — bringing the UI closer to a production-quality file viewer experience.

## Changes
- Add `SearchInput` and `IndentGuide` atoms; extend `Icon` with search, clear, collapse, expand, and refresh icons
- Add `ExplorerToolbar` molecule (collapse/expand/refresh actions) and `PathBar` molecule (clickable breadcrumb segments)
- Enhance `FileTreeItem` with indent guides and inline search match highlighting
- Upgrade `FileTree` to support search/filter with toolbar integration, and `FileViewerPanel` to incorporate the `PathBar`
- Make `FileIcon` extension-aware with per-language accent colors (tsx/jsx, ts/js, css, go, py, etc.)

---
**Stack:** `file-viewer` (PR 2 of 2)
*Generated with [Claude Code](https://claude.com/claude-code)*