### PR TITLE
Design Polish

### DIFF
--- a/app/frontend/index.html
+++ b/app/frontend/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Stack Bench</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/app/frontend/src/components/atoms/Icon/Icon.tsx
+++ b/app/frontend/src/components/atoms/Icon/Icon.tsx
@@ -85,6 +85,13 @@ const iconPaths: Record<string, React.ReactNode> = {
       <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
     </>
   ),
+  upload: (
+    <>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+      <polyline points="17 8 12 3 7 8" />
+      <line x1="12" y1="3" x2="12" y2="15" />
+    </>
+  ),
 };
 
 type IconName = keyof typeof iconPaths;

--- a/app/frontend/src/components/atoms/ViewedToggle/ViewedToggle.tsx
+++ b/app/frontend/src/components/atoms/ViewedToggle/ViewedToggle.tsx
@@ -1,0 +1,38 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { cn } from "@/lib/utils";
+import { Icon } from "@/components/atoms/Icon";
+
+interface ViewedToggleProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  viewed: boolean;
+  onChange: (viewed: boolean) => void;
+}
+
+const ViewedToggle = forwardRef<HTMLButtonElement, ViewedToggleProps>(
+  ({ viewed, onChange, className, ...props }, ref) => (
+    <button
+      ref={ref}
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onChange(!viewed);
+      }}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors select-none cursor-pointer",
+        viewed
+          ? "bg-[var(--accent-emerald-dim)] text-[var(--accent-emerald)]"
+          : "bg-transparent border border-[var(--border)] text-[var(--fg-muted)] hover:text-[var(--fg-default)] hover:border-[var(--fg-subtle)]",
+        className
+      )}
+      {...props}
+    >
+      {viewed && <Icon name="check" size="xs" className="shrink-0" />}
+      {viewed ? "Viewed" : "Mark viewed"}
+    </button>
+  )
+);
+
+ViewedToggle.displayName = "ViewedToggle";
+
+export { ViewedToggle };
+export type { ViewedToggleProps };

--- a/app/frontend/src/components/atoms/ViewedToggle/index.ts
+++ b/app/frontend/src/components/atoms/ViewedToggle/index.ts
@@ -1,0 +1,2 @@
+export { ViewedToggle } from "./ViewedToggle";
+export type { ViewedToggleProps } from "./ViewedToggle";

--- a/app/frontend/src/components/atoms/index.ts
+++ b/app/frontend/src/components/atoms/index.ts
@@ -35,3 +35,6 @@ export type { DiffBadgeProps } from "./DiffBadge";
 
 export { FileIcon, getFileColor } from "./FileIcon";
 export type { FileIconProps } from "./FileIcon";
+
+export { ViewedToggle } from "./ViewedToggle";
+export type { ViewedToggleProps } from "./ViewedToggle";

--- a/app/frontend/src/components/molecules/ActionBar/ActionBar.tsx
+++ b/app/frontend/src/components/molecules/ActionBar/ActionBar.tsx
@@ -1,19 +1,29 @@
-import { Button } from "@/components/atoms";
+import { Button, Icon } from "@/components/atoms";
 import { StatusBadge } from "@/components/molecules/StatusBadge";
 
 interface ActionBarProps {
   status: string;
   onPush?: () => void;
+  onRestack?: () => void;
 }
 
-function ActionBar({ status, onPush }: ActionBarProps) {
+function ActionBar({ status, onPush, onRestack }: ActionBarProps) {
   return (
     <div className="flex items-center justify-between px-6 py-3 bg-[var(--bg-surface)] border-t border-[var(--border)]">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-3">
         <StatusBadge status={status} />
         <span className="text-xs text-[var(--fg-muted)]">
           {status === "created" ? "Not yet pushed" : `Status: ${status}`}
         </span>
+        <Button
+          variant="subtle"
+          size="sm"
+          onClick={onRestack}
+          disabled={!onRestack}
+        >
+          <Icon name="refresh-cw" size="xs" />
+          Restack downstream
+        </Button>
       </div>
       <Button
         variant="primary"

--- a/app/frontend/src/components/molecules/DiffFileHeader/DiffFileHeader.tsx
+++ b/app/frontend/src/components/molecules/DiffFileHeader/DiffFileHeader.tsx
@@ -1,8 +1,8 @@
-import { Checkbox } from "@/components/atoms/Checkbox";
 import { DiffBadge } from "@/components/atoms/DiffBadge";
 import { DiffStat } from "@/components/atoms/DiffStat";
 import { FileIcon } from "@/components/atoms/FileIcon";
 import { Icon } from "@/components/atoms/Icon";
+import { ViewedToggle } from "@/components/atoms/ViewedToggle";
 import type { DiffFile } from "@/types/diff";
 
 interface DiffFileHeaderProps {
@@ -58,12 +58,8 @@ function DiffFileHeader({ file, expanded, viewed = false, onToggle, onViewedChan
       </span>
 
       {onViewedChange && (
-        <span className="shrink-0 ml-2" onClick={(e) => e.stopPropagation()}>
-          <Checkbox
-            checked={viewed}
-            onChange={onViewedChange}
-            label="Viewed"
-          />
+        <span className="shrink-0 ml-2">
+          <ViewedToggle viewed={viewed} onChange={onViewedChange} />
         </span>
       )}
     </div>

--- a/app/frontend/src/components/organisms/StackSidebar/StackSidebar.tsx
+++ b/app/frontend/src/components/organisms/StackSidebar/StackSidebar.tsx
@@ -1,4 +1,4 @@
-import { Icon } from "@/components/atoms";
+import { Button, Icon } from "@/components/atoms";
 import { StackConnector } from "@/components/molecules/StackConnector";
 import type { StackConnectorItem } from "@/components/molecules/StackConnector";
 
@@ -8,6 +8,8 @@ interface StackSidebarProps {
   items: StackConnectorItem[];
   activeIndex: number;
   onSelect: (index: number) => void;
+  onRestackAll?: () => void;
+  onPushStack?: () => void;
 }
 
 function StackSidebar({
@@ -16,6 +18,8 @@ function StackSidebar({
   items,
   activeIndex,
   onSelect,
+  onRestackAll,
+  onPushStack,
 }: StackSidebarProps) {
   return (
     <aside
@@ -36,11 +40,40 @@ function StackSidebar({
 
       {/* Branch list */}
       <div className="flex-1 overflow-y-auto px-1 py-2">
+        <div className="px-3 pb-2">
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--fg-subtle)]">
+            Stack
+          </span>
+        </div>
         <StackConnector
           items={items}
           activeIndex={activeIndex}
           onSelect={onSelect}
         />
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center gap-2 px-4 py-3 border-t border-[var(--border-muted)]">
+        <Button
+          variant="subtle"
+          size="sm"
+          className="flex-1"
+          onClick={onRestackAll}
+          disabled={!onRestackAll}
+        >
+          <Icon name="refresh-cw" size="xs" />
+          Restack all
+        </Button>
+        <Button
+          variant="subtle"
+          size="sm"
+          className="flex-1"
+          onClick={onPushStack}
+          disabled={!onPushStack}
+        >
+          <Icon name="upload" size="xs" />
+          Push stack
+        </Button>
       </div>
     </aside>
   );

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -31,6 +31,10 @@
   --purple: #bc8cff;             /* Reviews, special items */
   --yellow: #d29922;             /* Warnings, pending */
 
+  /* ── Emerald Accents ────────────────────────────────────── */
+  --accent-emerald: #6ee7b7;     /* Emerald accent (viewed, primary UI) */
+  --accent-emerald-dim: #065f46; /* Emerald background (viewed toggle bg) */
+
   /* ── Semantic Backgrounds ────────────────────────────────── */
   --green-bg: #12261e;           /* Diff addition background */
   --red-bg: #28171a;             /* Diff deletion background */
@@ -41,10 +45,10 @@
   --indent-guide-active: #30363d; /* Indent guide on hover scope */
 
   /* ── Typography ──────────────────────────────────────────── */
-  --font-sans: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-    "Liberation Mono", monospace;
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+    Consolas, "Liberation Mono", monospace;
 
   /* ── Spacing (for reference, Tailwind handles most) ──────── */
   --sidebar-width: 320px;


### PR DESCRIPTION
## Summary
Polish the frontend UI with a cohesive visual identity: IBM Plex typography, an emerald color palette for "viewed" states, and a more capable sidebar and action bar with stack-level operations.

## Changes
- Add `ViewedToggle` atom — replaces the plain checkbox in diff file headers with a styled pill button using the new emerald accent palette
- Introduce emerald CSS variables (`--accent-emerald`, `--accent-emerald-dim`) for consistent viewed/active state coloring
- Swap system fonts for IBM Plex Sans + IBM Plex Mono as the primary typeface pair
- Add "Restack downstream" to `ActionBar` and a footer with "Restack all" / "Push stack" actions to `StackSidebar`, surfacing stack-level operations at the right scope
- Add `upload` icon to support the new Push stack button

---
**Stack:** `round-2-polish` (PR 2 of 4)
*Generated with [Claude Code](https://claude.com/claude-code)*