### PR TITLE
Agent Panel

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -23,6 +23,10 @@ export function App() {
   const { data, loading, error } = useStackDetail();
   const [activeIndex, setActiveIndex] = useState(2);
   const [activeTab, setActiveTab] = useState("files");
+  const [agentOpen, setAgentOpen] = useState(false);
+
+  // TODO: Lift selectedLineCount from FilesChangedPanel in a future PR
+  const selectedLineCount = 0;
 
   const activeBranchId = data?.branches[activeIndex]?.branch.id;
   const { data: diffData } = useBranchDiff(activeBranchId);
@@ -77,6 +81,9 @@ export function App() {
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={setActiveTab}
+      agentOpen={agentOpen}
+      onAgentToggle={() => setAgentOpen((prev) => !prev)}
+      selectedLineCount={selectedLineCount}
     >
       {activeTab === "files" && (
         diffData ? (

--- a/app/frontend/src/components/atoms/Icon/Icon.tsx
+++ b/app/frontend/src/components/atoms/Icon/Icon.tsx
@@ -98,6 +98,18 @@ const iconPaths: Record<string, React.ReactNode> = {
       <path d="M19 13l.75 2.25L22 16l-2.25.75L19 19l-.75-2.25L16 16l2.25-.75L19 13z" />
     </>
   ),
+  sparkle: (
+    <>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83" />
+    </>
+  ),
+  send: (
+    <>
+      <line x1="22" y1="2" x2="11" y2="13" />
+      <polygon points="22 2 15 22 11 13 2 9 22 2" />
+    </>
+  ),
 };
 
 type IconName = keyof typeof iconPaths;

--- a/app/frontend/src/components/organisms/AgentPanel/AgentPanel.tsx
+++ b/app/frontend/src/components/organisms/AgentPanel/AgentPanel.tsx
@@ -1,0 +1,246 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { cn } from "@/lib/utils";
+import { Icon } from "@/components/atoms/Icon";
+
+type MessageRole = "system" | "user" | "assistant";
+
+interface AgentMessage {
+  role: MessageRole;
+  content: string;
+}
+
+interface AgentPanelProps {
+  isOpen: boolean;
+  onToggle: () => void;
+  selectedLineCount: number;
+  branchName: string;
+}
+
+const MOCK_RESPONSES = [
+  "I'll analyze those changes. The code looks well-structured with clean separation of concerns.",
+  "Looking at the diff, the implementation follows the established patterns. No issues flagged.",
+  "The changes are consistent with the existing codebase style. One minor suggestion: consider adding error boundaries around the new components.",
+  "Good approach. The component hierarchy follows atomic design principles correctly.",
+];
+
+function AgentPanel({
+  isOpen,
+  onToggle,
+  selectedLineCount,
+  branchName,
+}: AgentPanelProps) {
+  const [messages, setMessages] = useState<AgentMessage[]>([
+    { role: "system", content: `Watching branch ${branchName} — reviewing changes` },
+    {
+      role: "assistant",
+      content:
+        "This branch looks clean. I'm ready to help review the changes. Select some lines or ask me about the code.",
+    },
+  ]);
+  const [inputValue, setInputValue] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const responseIndexRef = useRef(0);
+
+  const scrollToBottom = useCallback(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, scrollToBottom]);
+
+  const handleSend = useCallback(() => {
+    const text = inputValue.trim();
+    if (!text) return;
+
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    setInputValue("");
+
+    // Mock assistant response after 500ms
+    setTimeout(() => {
+      const response =
+        MOCK_RESPONSES[responseIndexRef.current % MOCK_RESPONSES.length] ?? "";
+      responseIndexRef.current += 1;
+      setMessages((prev) => [...prev, { role: "assistant" as const, content: response }]);
+    }, 500);
+  }, [inputValue]);
+
+  const handleQuickAction = useCallback(
+    (action: string) => {
+      setMessages((prev) => [...prev, { role: "user", content: action }]);
+
+      setTimeout(() => {
+        const response =
+          MOCK_RESPONSES[responseIndexRef.current % MOCK_RESPONSES.length] ?? "";
+        responseIndexRef.current += 1;
+        setMessages((prev) => [...prev, { role: "assistant" as const, content: response }]);
+      }, 500);
+    },
+    []
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+      }
+    },
+    [handleSend]
+  );
+
+  // Collapsed state
+  if (!isOpen) {
+    return (
+      <button
+        onClick={onToggle}
+        className={cn(
+          "w-10 flex flex-col items-center gap-3 pt-4 shrink-0",
+          "bg-[var(--bg-surface)] border-l border-[var(--border)]",
+          "hover:bg-[var(--bg-surface-hover)] transition-colors cursor-pointer"
+        )}
+      >
+        <Icon name="sparkle" size="sm" className="text-[var(--fg-muted)]" />
+        <span
+          className="text-[var(--fg-muted)] text-xs font-medium tracking-wider"
+          style={{ writingMode: "vertical-rl" }}
+        >
+          Agent
+        </span>
+      </button>
+    );
+  }
+
+  // Expanded state
+  return (
+    <div
+      className={cn(
+        "w-[360px] shrink-0 flex flex-col",
+        "bg-[var(--bg-surface)] border-l border-[var(--border)]"
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2.5 border-b border-[var(--border)]">
+        <Icon name="sparkle" size="sm" className="text-[var(--accent-emerald)]" />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-[var(--fg-default)]">Agent</div>
+          <div className="text-xs text-[var(--fg-muted)] truncate">
+            Reviewing {branchName}
+          </div>
+        </div>
+        <button
+          onClick={onToggle}
+          className="p-1 rounded hover:bg-[var(--bg-surface-hover)] text-[var(--fg-muted)] hover:text-[var(--fg-default)] transition-colors"
+        >
+          <Icon name="x" size="sm" />
+        </button>
+      </div>
+
+      {/* Context banner */}
+      {selectedLineCount > 0 && (
+        <div className="px-3 py-2 bg-[var(--accent-emerald-dim)] text-[var(--accent-emerald)] text-xs font-medium">
+          {selectedLineCount} line{selectedLineCount !== 1 ? "s" : ""} selected as context
+        </div>
+      )}
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-auto p-3 space-y-3">
+        {messages.map((msg, i) => (
+          <MessageBubble key={i} message={msg} />
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Quick actions */}
+      <div className="px-3 pb-2 flex flex-wrap gap-1.5">
+        {["Explain this change", "Suggest improvements", "Check for bugs"].map(
+          (action) => (
+            <button
+              key={action}
+              onClick={() => handleQuickAction(action)}
+              className={cn(
+                "px-2.5 py-1 text-xs rounded-full",
+                "border border-[var(--border)] text-[var(--fg-muted)]",
+                "hover:bg-[var(--bg-surface-hover)] hover:text-[var(--fg-default)]",
+                "transition-colors"
+              )}
+            >
+              {action}
+            </button>
+          )
+        )}
+      </div>
+
+      {/* Input area */}
+      <div className="border-t border-[var(--border)] p-3">
+        <div className="flex gap-2">
+          <textarea
+            rows={2}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Ask about this code..."
+            className={cn(
+              "flex-1 resize-none rounded-md px-3 py-2 text-sm",
+              "bg-[var(--bg-inset)] text-[var(--fg-default)]",
+              "border border-[var(--border)] placeholder:text-[var(--fg-subtle)]",
+              "focus:outline-none focus:border-[var(--accent)]"
+            )}
+          />
+          <button
+            onClick={handleSend}
+            disabled={!inputValue.trim()}
+            className={cn(
+              "self-end p-2 rounded-md transition-colors",
+              "text-[var(--fg-muted)] hover:text-[var(--fg-default)]",
+              "hover:bg-[var(--bg-surface-hover)]",
+              "disabled:opacity-40 disabled:cursor-not-allowed"
+            )}
+          >
+            <Icon name="send" size="sm" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: AgentMessage }) {
+  if (message.role === "system") {
+    return (
+      <div className="text-center">
+        <span className="text-xs italic text-[var(--fg-subtle)]">
+          {message.content}
+        </span>
+      </div>
+    );
+  }
+
+  if (message.role === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[85%] rounded-lg px-3 py-2 bg-[var(--bg-canvas)] text-sm text-[var(--fg-default)]">
+          {message.content}
+        </div>
+      </div>
+    );
+  }
+
+  // assistant
+  return (
+    <div className="max-w-[85%]">
+      <div className="flex items-center gap-1.5 mb-1">
+        <Icon name="sparkle" size="xs" className="text-[var(--accent-emerald)]" />
+        <span className="text-xs font-medium text-[var(--fg-muted)]">Agent</span>
+      </div>
+      <div className="rounded-lg px-3 py-2 bg-[var(--bg-surface-hover)] text-sm text-[var(--fg-default)]">
+        {message.content}
+      </div>
+    </div>
+  );
+}
+
+AgentPanel.displayName = "AgentPanel";
+
+export { AgentPanel };
+export type { AgentPanelProps, AgentMessage };

--- a/app/frontend/src/components/organisms/AgentPanel/index.ts
+++ b/app/frontend/src/components/organisms/AgentPanel/index.ts
@@ -1,0 +1,2 @@
+export { AgentPanel } from "./AgentPanel";
+export type { AgentPanelProps, AgentMessage } from "./AgentPanel";

--- a/app/frontend/src/components/organisms/index.ts
+++ b/app/frontend/src/components/organisms/index.ts
@@ -3,3 +3,6 @@ export type { StackSidebarProps } from "./StackSidebar";
 
 export { FilesChangedPanel } from "./FilesChangedPanel";
 export type { FilesChangedPanelProps } from "./FilesChangedPanel";
+
+export { AgentPanel } from "./AgentPanel";
+export type { AgentPanelProps, AgentMessage } from "./AgentPanel";

--- a/app/frontend/src/components/templates/AppShell/AppShell.tsx
+++ b/app/frontend/src/components/templates/AppShell/AppShell.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { StackSidebar } from "@/components/organisms/StackSidebar";
+import { AgentPanel } from "@/components/organisms/AgentPanel";
 import { PRHeader } from "@/components/molecules/PRHeader";
 import { TabBar } from "@/components/molecules/TabBar";
 import type { TabItem } from "@/components/molecules/TabBar";
@@ -17,6 +18,9 @@ interface AppShellProps {
   tabs: TabItem[];
   activeTab: string;
   onTabChange: (tabId: string) => void;
+  agentOpen: boolean;
+  onAgentToggle: () => void;
+  selectedLineCount: number;
   children?: ReactNode;
 }
 
@@ -36,6 +40,9 @@ function AppShell({
   tabs,
   activeTab,
   onTabChange,
+  agentOpen,
+  onAgentToggle,
+  selectedLineCount,
   children,
 }: AppShellProps) {
   // Derive PRHeader props from the active branch
@@ -81,6 +88,12 @@ function AppShell({
         </div>
         <ActionBar status={displayStatus} />
       </main>
+      <AgentPanel
+        isOpen={agentOpen}
+        onToggle={onAgentToggle}
+        selectedLineCount={selectedLineCount}
+        branchName={headBranch}
+      />
     </div>
   );
 }

--- a/app/frontend/src/index.css
+++ b/app/frontend/src/index.css
@@ -39,6 +39,8 @@
   --green-bg: #12261e;           /* Diff addition background */
   --red-bg: #28171a;             /* Diff deletion background */
   --accent-muted: #1f6feb33;     /* Selected/active background */
+  --accent-emerald: #6ee7b7;     /* Emerald accent text */
+  --accent-emerald-dim: #065f46; /* Emerald accent background */
 
   /* ── Indent Guides ─────────────────────────────────────── */
   --indent-guide: #21262d;       /* Indent guide line color */


### PR DESCRIPTION
## Summary
Introduces a collapsible agent chat panel as a new organism in the UI shell, wired up with mock conversation state to validate the interaction design before connecting to a real backend.

## Changes
- Add `AgentPanel` organism with collapsed (icon strip) and expanded (360px chat) states, toggled from `AppShell`
- Implement mock chat loop with quick-action chips, free-text input, and auto-scroll — rotating through canned responses at 500ms delay
- Show a context banner when lines are selected (prop plumbed through; line count tracking deferred to a future PR)
- Add `sparkle` and `send` icons to the shared `Icon` atom registry

---
**Stack:** `round-2-polish` (PR 4 of 4)
*Generated with [Claude Code](https://claude.com/claude-code)*