### PR TITLE
Short Refs

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -18,10 +18,7 @@ import type { DiffData } from "@/types/diff";
 import type { SidebarMode } from "@/types/sidebar";
 import type { CIStatus, StackSummary, ActivityLogEntry } from "@/types/activity";
 
-function branchTitle(name: string): string {
-  const parts = name.split("/");
-  return parts[parts.length - 1] ?? name;
-}
+import { shortBranch } from "@/lib/short-branch";
 
 
 /** Status values that count as "draft" (no PR or local-only) */
@@ -130,7 +127,7 @@ export function App() {
 
     return {
       id: b.branch.id,
-      title: branchTitle(b.branch.name),
+      title: shortBranch(b.branch.name),
       status: displayStatus,
       additions: diffResult?.total_additions,
       deletions: diffResult?.total_deletions,

--- a/app/frontend/src/components/atoms/BranchMeta/BranchMeta.tsx
+++ b/app/frontend/src/components/atoms/BranchMeta/BranchMeta.tsx
@@ -3,10 +3,12 @@ import { cn } from "@/lib/utils";
 interface BranchMetaProps {
   base: string;
   head: string;
+  fullBase?: string;
+  fullHead?: string;
   className?: string;
 }
 
-function BranchMeta({ base, head, className }: BranchMetaProps) {
+function BranchMeta({ base, head, fullBase, fullHead, className }: BranchMetaProps) {
   return (
     <span
       className={cn(
@@ -14,9 +16,9 @@ function BranchMeta({ base, head, className }: BranchMetaProps) {
         className
       )}
     >
-      <span>{base}</span>
+      <span title={fullBase ?? base}>{base}</span>
       <span className="text-[var(--accent)]">&larr;</span>
-      <span>{head}</span>
+      <span title={fullHead ?? head}>{head}</span>
     </span>
   );
 }

--- a/app/frontend/src/components/molecules/PRHeader/PRHeader.tsx
+++ b/app/frontend/src/components/molecules/PRHeader/PRHeader.tsx
@@ -7,6 +7,8 @@ interface PRHeaderProps {
   title: string;
   baseBranch: string;
   headBranch: string;
+  fullBaseBranch?: string;
+  fullHeadBranch?: string;
   description?: string | null;
   status?: string;
   fileCount?: number;
@@ -21,7 +23,7 @@ interface PRHeaderProps {
 }
 
 function PRHeader({
-  title, baseBranch, headBranch, description, status,
+  title, baseBranch, headBranch, fullBaseBranch, fullHeadBranch, description, status,
   fileCount, additions, deletions,
   onPush, onRestack, onCollapseAll, onExpandAll,
   floatingComments, onToggleCommentMode,
@@ -34,7 +36,7 @@ function PRHeader({
             {title}
           </h2>
           <div className="mt-1 flex items-center gap-3">
-            <BranchMeta base={baseBranch} head={headBranch} />
+            <BranchMeta base={baseBranch} head={headBranch} fullBase={fullBaseBranch} fullHead={fullHeadBranch} />
             {status && <StatusBadge status={status} />}
           </div>
           {description && (

--- a/app/frontend/src/components/templates/AppShell/AppShell.tsx
+++ b/app/frontend/src/components/templates/AppShell/AppShell.tsx
@@ -54,11 +54,7 @@ interface AppShellProps {
   onToggleCommentMode?: () => void;
 }
 
-/** Extract short branch name from full ref: "dug/frontend-mvp/3-stack-nav" → "3-stack-nav" */
-function shortBranch(name: string): string {
-  const parts = name.split("/");
-  return parts[parts.length - 1] ?? name;
-}
+import { shortBranch } from "@/lib/short-branch";
 
 function AppShell({
   stackName,
@@ -102,8 +98,12 @@ function AppShell({
   const description = pr?.description ?? (pr ? null : "No pull request");
   const headBranch = shortBranch(branchName);
 
+  // Full branch names for tooltips
+  const fullHeadBranch = activeBranch?.branch.name ?? "";
+
   // Base branch: for position 1, base is trunk. For others, it's the previous branch.
   const position = activeBranch?.branch.position ?? 1;
+  // items[].title is already short — we don't have the full base ref, so tooltip falls back to short name
   const baseBranch = position <= 1 ? trunk : shortBranch(
     // Find branch at position - 1
     items[activeIndex - 1]?.title ?? trunk
@@ -143,6 +143,7 @@ function AppShell({
           title={title}
           baseBranch={baseBranch}
           headBranch={headBranch}
+          fullHeadBranch={fullHeadBranch}
           description={description}
           status={displayStatus}
           fileCount={fileCount}

--- a/app/frontend/src/lib/short-branch.ts
+++ b/app/frontend/src/lib/short-branch.ts
@@ -1,0 +1,5 @@
+/** Extract short branch name from full ref: "dug/frontend-mvp/3-stack-nav" → "3-stack-nav" */
+export function shortBranch(name: string): string {
+  const parts = name.split("/");
+  return parts[parts.length - 1] ?? name;
+}


### PR DESCRIPTION
## Summary
Extract the duplicated `shortBranch` utility into a shared `@/lib/short-branch` module and wire up full branch name tooltips on `BranchMeta` so users can hover to see the complete ref path.

## Changes
- Add `@/lib/short-branch` as single source of truth, replacing inline copies in `App.tsx` and `AppShell.tsx`
- Add optional `fullBase`/`fullHead` props to `BranchMeta` for hover tooltips, falling back to the short name when not provided
- Thread `fullHeadBranch` from `AppShell` down through `PRHeader` → `BranchMeta`; base tooltip left as short name pending full ref availability in the items list

---
**Stack:** `mvp-data-wiring` (PR 6 of 10)
*Generated with [Claude Code](https://claude.com/claude-code)*