### PR TITLE
Loading Skeletons

### DIFF
--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import type { ChangedFileInfo } from "@/components/organisms/FileTree";
 import type { DiffData } from "@/types/diff";
 import type { SidebarMode } from "@/types/sidebar";
 import type { CIStatus, StackSummary, ActivityLogEntry } from "@/types/activity";
+import { DiffSkeleton } from "@/components/organisms/FilesChangedPanel/DiffSkeleton";
 
 import { shortBranch } from "@/lib/short-branch";
 
@@ -58,9 +59,9 @@ export function App() {
 
   const stackId = data?.stack.id;
   const activeBranchId = data?.branches[activeIndex]?.branch.id;
-  const { data: diffData } = useBranchDiff(stackId, activeBranchId);
-  const { data: fileTree } = useFileTree(stackId, activeBranchId);
-  const { data: fileContent } = useFileContent(stackId, activeBranchId, sidebarMode === "files" ? selectedPath : null);
+  const { data: diffData, loading: diffLoading } = useBranchDiff(stackId, activeBranchId);
+  const { data: fileTree, loading: treeLoading } = useFileTree(stackId, activeBranchId);
+  const { data: fileContent, loading: contentLoading } = useFileContent(stackId, activeBranchId, sidebarMode === "files" ? selectedPath : null);
 
   // Fetch all stacks for the same project (for the stack switcher)
   const projectId = data?.stack.project_id;
@@ -205,9 +206,13 @@ export function App() {
       onExpandAll={() => setForceExpanded(true)}
       floatingComments={floatingComments}
       onToggleCommentMode={() => setFloatingComments((prev) => !prev)}
+      diffLoading={diffLoading}
+      treeLoading={treeLoading}
     >
       {sidebarMode === "diffs" && (
-        diffData ? (
+        diffLoading ? (
+          <DiffSkeleton />
+        ) : diffData ? (
           <FilesChangedPanel
             diffData={diffData}
             forceExpanded={forceExpanded}
@@ -223,7 +228,9 @@ export function App() {
         )
       )}
       {sidebarMode === "files" && (
-        fileContent ? (
+        contentLoading ? (
+          <DiffSkeleton />
+        ) : fileContent ? (
           <>
             <PathBar path={fileContent.path} />
             <div className="flex-1 min-h-0 overflow-hidden">

--- a/app/frontend/src/components/atoms/index.ts
+++ b/app/frontend/src/components/atoms/index.ts
@@ -50,3 +50,6 @@ export type { PRNumberProps } from "./PRNumber";
 
 export { RestackBadge } from "./RestackBadge";
 export type { RestackBadgeProps } from "./RestackBadge";
+
+export { Skeleton } from "./Skeleton";
+export type { SkeletonProps } from "./Skeleton";

--- a/app/frontend/src/components/organisms/StackSidebar/StackSidebar.tsx
+++ b/app/frontend/src/components/organisms/StackSidebar/StackSidebar.tsx
@@ -14,6 +14,7 @@ import type { SidebarMode } from "@/types/sidebar";
 import type { FileTreeNode } from "@/types/file-tree";
 import type { Stack } from "@/types/stack";
 import type { StackSummary, ActivityLogEntry } from "@/types/activity";
+import { TreeSkeleton } from "./TreeSkeleton";
 
 interface StackSidebarProps {
   stackName: string;
@@ -39,6 +40,8 @@ interface StackSidebarProps {
   diffFileCount?: number;
   onRefresh?: () => void;
   changedFiles?: Map<string, ChangedFileInfo>;
+  diffLoading?: boolean;
+  treeLoading?: boolean;
 }
 
 function StackSidebar({
@@ -64,6 +67,8 @@ function StackSidebar({
   diffFileCount,
   onRefresh,
   changedFiles,
+  diffLoading,
+  treeLoading,
 }: StackSidebarProps) {
   const isFilesMode = sidebarMode === "files";
   const [stackExpanded, setStackExpanded] = useState(true);
@@ -153,20 +158,28 @@ function StackSidebar({
       {/* Tree area */}
       <div className="flex-1 overflow-y-auto min-h-0">
         {sidebarMode === "diffs" ? (
-          <DiffFileList
-            files={diffFiles}
-            selectedPath={selectedPath}
-            onSelectFile={onSelectFile}
-          />
-        ) : (
-          fileTree && (
-            <FileTree
-              tree={fileTree}
+          diffLoading ? (
+            <TreeSkeleton />
+          ) : (
+            <DiffFileList
+              files={diffFiles}
               selectedPath={selectedPath}
               onSelectFile={onSelectFile}
-              onRefresh={onRefresh}
-              changedFiles={changedFiles}
             />
+          )
+        ) : (
+          treeLoading ? (
+            <TreeSkeleton />
+          ) : (
+            fileTree && (
+              <FileTree
+                tree={fileTree}
+                selectedPath={selectedPath}
+                onSelectFile={onSelectFile}
+                onRefresh={onRefresh}
+                changedFiles={changedFiles}
+              />
+            )
           )
         )}
       </div>

--- a/app/frontend/src/components/templates/AppShell/AppShell.tsx
+++ b/app/frontend/src/components/templates/AppShell/AppShell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { StackSidebar } from "@/components/organisms/StackSidebar";
 import { AgentPanel } from "@/components/organisms/AgentPanel";
 import { PRHeader } from "@/components/molecules/PRHeader";
+import { HeaderSkeleton } from "@/components/molecules/PRHeader/HeaderSkeleton";
 import type { StackConnectorItem } from "@/components/molecules/StackConnector";
 import type { DiffFileListItem } from "@/components/molecules/DiffFileList";
 import type { BranchWithPR, Stack } from "@/types/stack";
@@ -52,6 +53,8 @@ interface AppShellProps {
   onExpandAll?: () => void;
   floatingComments?: boolean;
   onToggleCommentMode?: () => void;
+  diffLoading?: boolean;
+  treeLoading?: boolean;
 }
 
 import { shortBranch } from "@/lib/short-branch";
@@ -90,6 +93,8 @@ function AppShell({
   onExpandAll,
   floatingComments,
   onToggleCommentMode,
+  diffLoading,
+  treeLoading,
 }: AppShellProps) {
   // Derive PRHeader props from the active branch
   const pr = activeBranch?.pull_request;
@@ -137,23 +142,29 @@ function AppShell({
         diffFileCount={diffFileCount}
         onRefresh={onRefresh}
         changedFiles={changedFiles}
+        diffLoading={diffLoading}
+        treeLoading={treeLoading}
       />
       <main className="flex-1 flex flex-col min-w-0">
-        <PRHeader
-          title={title}
-          baseBranch={baseBranch}
-          headBranch={headBranch}
-          fullHeadBranch={fullHeadBranch}
-          description={description}
-          status={displayStatus}
-          fileCount={fileCount}
-          additions={additions}
-          deletions={deletions}
-          onCollapseAll={onCollapseAll}
-          onExpandAll={onExpandAll}
-          floatingComments={floatingComments}
-          onToggleCommentMode={onToggleCommentMode}
-        />
+        {diffLoading ? (
+          <HeaderSkeleton />
+        ) : (
+          <PRHeader
+            title={title}
+            baseBranch={baseBranch}
+            headBranch={headBranch}
+            fullHeadBranch={fullHeadBranch}
+            description={description}
+            status={displayStatus}
+            fileCount={fileCount}
+            additions={additions}
+            deletions={deletions}
+            onCollapseAll={onCollapseAll}
+            onExpandAll={onExpandAll}
+            floatingComments={floatingComments}
+            onToggleCommentMode={onToggleCommentMode}
+          />
+        )}
         <div className="flex-1 overflow-auto">
           {children}
         </div>


### PR DESCRIPTION
## Summary
Replace blank loading states with animated skeleton placeholders across the diff viewer, file tree, and PR header so the UI feels responsive during data fetches rather than showing empty areas.

## Changes
- Add `Skeleton` atom with pulse animation as the base primitive
- Compose `DiffSkeleton`, `TreeSkeleton`, and `HeaderSkeleton` to mimic the shape of each content area
- Wire `diffLoading` and `treeLoading` from `useBranchDiff`/`useFileTree` hooks down through `App → AppShell → StackSidebar/PRHeader`, swapping in skeletons while fetches are in-flight

---
**Stack:** `mvp-data-wiring` (PR 7 of 10)
*Generated with [Claude Code](https://claude.com/claude-code)*