### PR TITLE
Ci Status Dots

### DIFF
--- a/app/backend/__tests__/molecules/test_github_adapter.py
+++ b/app/backend/__tests__/molecules/test_github_adapter.py
@@ -12,6 +12,7 @@ import pytest
 from pattern_stack.atoms.cache import reset_cache
 
 from molecules.providers.github_adapter import (
+    CheckStatusResult,
     DiffData,
     DiffFile,
     DiffHunk,
@@ -548,6 +549,121 @@ class TestGitHubAdapterAuth:
         adapter = GitHubAdapter(token="")
         headers = dict(adapter._client.headers)
         assert "authorization" not in {k.lower() for k in headers}
+
+
+# ---------------------------------------------------------------------------
+# GitHubAdapter.get_check_status
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterGetCheckStatus:
+    @pytest.mark.unit
+    async def test_all_passing(self) -> None:
+        check_runs_response = {
+            "total_count": 2,
+            "check_runs": [
+                {"name": "lint", "status": "completed", "conclusion": "success"},
+                {"name": "test", "status": "completed", "conclusion": "success"},
+            ],
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert "/commits/abc123/check-runs" in str(request.url)
+            return _make_response(check_runs_response)
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_status("o", "r", "abc123")
+
+        assert isinstance(result, CheckStatusResult)
+        assert result.status == "pass"
+        assert result.total == 2
+        assert result.passed == 2
+        assert result.failed == 0
+        assert result.pending == 0
+
+    @pytest.mark.unit
+    async def test_some_failing(self) -> None:
+        check_runs_response = {
+            "total_count": 3,
+            "check_runs": [
+                {"name": "lint", "status": "completed", "conclusion": "success"},
+                {"name": "test", "status": "completed", "conclusion": "failure"},
+                {"name": "build", "status": "completed", "conclusion": "success"},
+            ],
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_response(check_runs_response)
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_status("o", "r", "sha1")
+
+        assert result.status == "fail"
+        assert result.total == 3
+        assert result.passed == 2
+        assert result.failed == 1
+        assert result.pending == 0
+
+    @pytest.mark.unit
+    async def test_some_pending(self) -> None:
+        check_runs_response = {
+            "total_count": 2,
+            "check_runs": [
+                {"name": "lint", "status": "completed", "conclusion": "success"},
+                {"name": "test", "status": "in_progress", "conclusion": None},
+            ],
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_response(check_runs_response)
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_status("o", "r", "sha2")
+
+        assert result.status == "pending"
+        assert result.total == 2
+        assert result.passed == 1
+        assert result.failed == 0
+        assert result.pending == 1
+
+    @pytest.mark.unit
+    async def test_no_check_runs(self) -> None:
+        check_runs_response = {
+            "total_count": 0,
+            "check_runs": [],
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_response(check_runs_response)
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_status("o", "r", "sha3")
+
+        assert result.status == "none"
+        assert result.total == 0
+
+    @pytest.mark.unit
+    async def test_check_status_is_cached(self) -> None:
+        call_count = 0
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return _make_response({"total_count": 0, "check_runs": []})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        await adapter.get_check_status("o", "r", "sha4")
+        await adapter.get_check_status("o", "r", "sha4")
+        assert call_count == 1
+
+    @pytest.mark.unit
+    async def test_error_propagates(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=404, json={"message": "Not Found"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubNotFoundError):
+            await adapter.get_check_status("o", "r", "missing")
 
 
 # ---------------------------------------------------------------------------

--- a/app/backend/src/molecules/apis/stack_api.py
+++ b/app/backend/src/molecules/apis/stack_api.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING
 
 from features.branches.schemas.output import BranchResponse
@@ -16,6 +18,8 @@ if TYPE_CHECKING:
 
     from features.review_comments.schemas.input import ReviewCommentCreate, ReviewCommentUpdate
     from molecules.providers.github_adapter import DiffData, FileContent, FileTreeNode, GitHubAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class StackDetailResponse:
@@ -76,6 +80,32 @@ class StackAPI:
                     "pull_request": pr_resp.model_dump() if pr_resp else None,
                 }
             )
+
+        # Fetch CI status for each branch that has a PR and a head_sha
+        if self.github is not None:
+            ci_tasks = []
+            ci_indices: list[int] = []
+            for i, bd in enumerate(data["branches"]):
+                branch = bd["branch"]
+                pr = bd["pull_request"]
+                if pr is not None and branch.head_sha:
+                    from molecules.providers.github_adapter import parse_owner_repo
+
+                    workspace = await self.entity.workspace_service.get(self.db, branch.workspace_id)
+                    if workspace is not None:
+                        owner, repo = parse_owner_repo(workspace.repo_url)
+                        ci_tasks.append(self.github.get_check_status(owner, repo, branch.head_sha))
+                        ci_indices.append(i)
+
+            if ci_tasks:
+                results = await asyncio.gather(*ci_tasks, return_exceptions=True)
+                for idx, result in zip(ci_indices, results):
+                    if isinstance(result, BaseException):
+                        logger.warning("Failed to fetch CI status for branch %s: %s", branches[idx]["branch"]["name"], result)
+                        branches[idx]["ci_status"] = "none"
+                    else:
+                        branches[idx]["ci_status"] = result.status
+
         return {
             "stack": StackResponse.model_validate(stack).model_dump(),
             "branches": branches,

--- a/app/backend/src/molecules/providers/github_adapter.py
+++ b/app/backend/src/molecules/providers/github_adapter.py
@@ -151,6 +151,15 @@ def _detect_language(path: str) -> str | None:
 _MAX_CONTENT_SIZE = 100 * 1024  # 100KB
 _CACHE_NS = "github"
 _CACHE_TTL = 3600  # 1 hour — git SHAs are content-addressed, safe to cache long
+_CI_CACHE_TTL = 300  # 5 minutes — CI status changes frequently
+
+
+class CheckStatusResult(BaseModel):
+    status: str  # "pass" | "fail" | "pending" | "none"
+    total: int
+    passed: int
+    failed: int
+    pending: int
 
 
 # ---------------------------------------------------------------------------
@@ -504,3 +513,47 @@ class GitHubAdapter:
 
         tasks = [self.get_diff(owner, repo, base, head) for _, base, head in branches]
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def get_check_status(self, owner: str, repo: str, ref: str) -> CheckStatusResult:
+        """Get aggregated CI check status for a commit ref."""
+        cache_key = f"checks:{owner}/{repo}:{ref}"
+        cached = await self._cache.get(cache_key, namespace=_CACHE_NS)
+        if cached is not None:
+            return CheckStatusResult.model_validate(cached)
+
+        response = await self._client.get(f"/repos/{owner}/{repo}/commits/{ref}/check-runs")
+        self._raise_for_status(response)
+        data = response.json()
+
+        check_runs: list[dict[str, object]] = data.get("check_runs", [])
+        total = len(check_runs)
+
+        if total == 0:
+            result = CheckStatusResult(status="none", total=0, passed=0, failed=0, pending=0)
+        else:
+            passed = 0
+            failed = 0
+            pending = 0
+            for run in check_runs:
+                status = str(run.get("status", ""))
+                conclusion = run.get("conclusion")
+                if status != "completed":
+                    pending += 1
+                elif conclusion == "success":
+                    passed += 1
+                else:
+                    failed += 1
+
+            if pending > 0:
+                agg_status = "pending"
+            elif failed > 0:
+                agg_status = "fail"
+            else:
+                agg_status = "pass"
+
+            result = CheckStatusResult(
+                status=agg_status, total=total, passed=passed, failed=failed, pending=pending
+            )
+
+        await self._cache.set(cache_key, result.model_dump(), ttl=_CI_CACHE_TTL, namespace=_CACHE_NS)
+        return result

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -133,7 +133,7 @@ export function App() {
       additions: diffResult?.total_additions,
       deletions: diffResult?.total_deletions,
       prNumber: b.pull_request?.external_id ?? null,
-      ciStatus: "none" as CIStatus,
+      ciStatus: (b.ci_status ?? "none") as CIStatus,
       needsRestack: false,
     };
   });

--- a/app/frontend/src/types/stack.ts
+++ b/app/frontend/src/types/stack.ts
@@ -40,6 +40,7 @@ export interface PullRequest {
 export interface BranchWithPR {
   branch: Branch;
   pull_request: PullRequest | null;
+  ci_status?: string;
 }
 
 export interface StackDetail {


### PR DESCRIPTION
## Summary
Replace hardcoded CI status dots with live data from GitHub's check-runs API, fetching and aggregating pass/fail/pending state per branch in parallel during stack detail load.

## Changes
- Add `get_check_status()` to `GitHubAdapter` — aggregates check-runs into `CheckStatusResult` (pass/fail/pending/none) with a 5-minute cache
- Enrich `StackDetailResponse` with `ci_status` per branch using `asyncio.gather` for concurrent fetches, with graceful fallback to `"none"` on errors
- Wire `ci_status` from the API response into `StackConnectorItem.ciStatus` in `App.tsx`, replacing the hardcoded `"none"`
- Add `ci_status` field to the `BranchWithPR` frontend type
- Full test coverage for all aggregation states (all pass, some fail, pending, empty, caching, 404 error)

---
**Stack:** `mvp-data-wiring` (PR 8 of 10)
*Generated with [Claude Code](https://claude.com/claude-code)*