### PR TITLE
Mark Pr Ready

### DIFF
--- a/app/backend/__tests__/molecules/test_github_adapter.py
+++ b/app/backend/__tests__/molecules/test_github_adapter.py
@@ -667,6 +667,48 @@ class TestGitHubAdapterGetCheckStatus:
 
 
 # ---------------------------------------------------------------------------
+# GitHubAdapter.mark_pr_ready
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterMarkPRReady:
+    @pytest.mark.unit
+    async def test_sends_patch_with_draft_false(self) -> None:
+        captured_request: dict[str, object] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured_request["url"] = str(request.url)
+            captured_request["method"] = request.method
+            captured_request["body"] = request.content.decode()
+            return _make_response({"id": 1, "draft": False})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        await adapter.mark_pr_ready("myorg", "myrepo", 42)
+
+        assert "/repos/myorg/myrepo/pulls/42" in str(captured_request["url"])
+        assert captured_request["method"] == "PATCH"
+        assert '"draft": false' in str(captured_request["body"]) or '"draft":false' in str(captured_request["body"])
+
+    @pytest.mark.unit
+    async def test_raises_on_404(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=404, json={"message": "Not Found"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubNotFoundError):
+            await adapter.mark_pr_ready("o", "r", 999)
+
+    @pytest.mark.unit
+    async def test_raises_on_422(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=422, json={"message": "Validation failed"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubAPIError):
+            await adapter.mark_pr_ready("o", "r", 1)
+
+
+# ---------------------------------------------------------------------------
 # DTO serialization round-trip
 # ---------------------------------------------------------------------------
 

--- a/app/backend/src/molecules/apis/stack_api.py
+++ b/app/backend/src/molecules/apis/stack_api.py
@@ -229,6 +229,35 @@ class StackAPI:
         await self.db.commit()
         return {"stack_id": str(stack_id), "merged": results}
 
+    async def mark_pr_ready(self, stack_id: UUID, branch_id: UUID) -> PullRequestResponse:
+        """Mark a draft PR as ready for review via GitHub API and transition local state."""
+        if self.github is None:
+            msg = "GitHubAdapter not configured"
+            raise RuntimeError(msg)
+
+        from features.pull_requests.service import PullRequestService
+
+        pr_svc = PullRequestService()
+        pr = await pr_svc.get_by_branch(self.db, branch_id)
+        if pr is None:
+            msg = f"No pull request found for branch {branch_id}"
+            raise ValueError(msg)
+
+        if pr.state != "draft":
+            msg = f"PR is not in draft state (current: {pr.state})"
+            raise ValueError(msg)
+
+        if pr.external_id is None:
+            msg = f"PR for branch {branch_id} has no GitHub PR number"
+            raise ValueError(msg)
+
+        owner, repo, _, _ = await self.entity.get_branch_repo_context(branch_id)
+        await self.github.mark_pr_ready(owner, repo, pr.external_id)
+        pr.transition_to("open")
+        await self.db.commit()
+        await self.db.refresh(pr)
+        return PullRequestResponse.model_validate(pr)
+
     # --- Review comments (Stack Bench local, GitHub sync optional) ---
 
     async def create_comment(self, data: ReviewCommentCreate) -> ReviewCommentResponse:

--- a/app/backend/src/organisms/api/routers/stacks.py
+++ b/app/backend/src/organisms/api/routers/stacks.py
@@ -178,6 +178,22 @@ async def link_external_pr(
     return await api.link_external_pr(pull_request_id, data.external_id, data.external_url)
 
 
+# --- Mark PR ready endpoint ---
+
+
+@router.post(
+    "/{stack_id}/branches/{branch_id}/pr/ready",
+    response_model=PullRequestResponse,
+)
+async def mark_pr_ready(
+    stack_id: UUID,
+    branch_id: UUID,
+    api: StackAPIDep,
+) -> PullRequestResponse:
+    """Mark a draft PR as ready for review via GitHub API."""
+    return await api.mark_pr_ready(stack_id, branch_id)
+
+
 # --- Git data endpoints (read-through via GitHub API) ---
 
 

--- a/app/frontend/src/App.tsx
+++ b/app/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { useStackList } from "@/hooks/useStackList";
 import { useBranchDiff, branchDiffKeys } from "@/hooks/useBranchDiff";
 import { useFileTree } from "@/hooks/useFileTree";
 import { useFileContent } from "@/hooks/useFileContent";
+import { useMarkReady } from "@/hooks/useMarkReady";
 import { mockActivityEntries } from "@/lib/mock-activity-data";
 import type { StackConnectorItem } from "@/components/molecules";
 import type { DiffFileListItem } from "@/components/molecules/DiffFileList";
@@ -62,6 +63,7 @@ export function App() {
   const { data: diffData, loading: diffLoading } = useBranchDiff(stackId, activeBranchId);
   const { data: fileTree, loading: treeLoading } = useFileTree(stackId, activeBranchId);
   const { data: fileContent, loading: contentLoading } = useFileContent(stackId, activeBranchId, sidebarMode === "files" ? selectedPath : null);
+  const markReady = useMarkReady(stackId, activeBranchId);
 
   // Fetch all stacks for the same project (for the stack switcher)
   const projectId = data?.stack.project_id;
@@ -199,6 +201,7 @@ export function App() {
         }
       }}
       onClearActivity={() => setActivityEntries([])}
+      onMarkReady={() => markReady.mutate()}
       fileCount={diffData?.files.length}
       additions={diffData?.total_additions}
       deletions={diffData?.total_deletions}

--- a/app/frontend/src/components/templates/AppShell/AppShell.tsx
+++ b/app/frontend/src/components/templates/AppShell/AppShell.tsx
@@ -45,6 +45,9 @@ interface AppShellProps {
   stacks?: Stack[];
   onStackChange?: (id: string) => void;
 
+  // PR action props
+  onMarkReady?: () => void;
+
   // Diff toolbar props
   fileCount?: number;
   additions?: number;
@@ -86,6 +89,7 @@ function AppShell({
   onSync,
   onMerge,
   onClearActivity,
+  onMarkReady,
   fileCount,
   additions,
   deletions,
@@ -159,6 +163,7 @@ function AppShell({
             fileCount={fileCount}
             additions={additions}
             deletions={deletions}
+            onPush={displayStatus === "draft" ? onMarkReady : undefined}
             onCollapseAll={onCollapseAll}
             onExpandAll={onExpandAll}
             floatingComments={floatingComments}

--- a/app/frontend/src/hooks/useMarkReady.ts
+++ b/app/frontend/src/hooks/useMarkReady.ts
@@ -1,0 +1,23 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/generated/api/client";
+import { stackDetailKeys } from "@/hooks/useStackDetail";
+
+export function useMarkReady(stackId?: string, branchId?: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!stackId || !branchId) {
+        throw new Error("stackId and branchId are required");
+      }
+      return apiClient.post(
+        `/api/v1/stacks/${stackId}/branches/${branchId}/pr/ready`,
+      );
+    },
+    onSuccess: () => {
+      if (stackId) {
+        queryClient.invalidateQueries({ queryKey: stackDetailKeys.detail(stackId) });
+      }
+    },
+  });
+}


### PR DESCRIPTION
## Summary
Wire the "Mark PR Ready" button to the GitHub API, completing the draft→open PR transition flow. This connects the existing `PRHeader` push button to a new backend endpoint that calls GitHub and updates local PR state.

## Changes
- Add `mark_pr_ready()` to `StackAPI` with guard rails for non-draft PRs and missing GitHub PR numbers
- Expose `POST /stacks/{stack_id}/branches/{branch_id}/pr/ready` endpoint
- Add `useMarkReady` mutation hook that invalidates stack detail cache on success
- Wire `onMarkReady` down through `App → AppShell → PRHeader.onPush`, gated on `displayStatus === "draft"`
- Add unit tests covering the happy path, 404, and 422 error cases for `GitHubAdapter.mark_pr_ready`

---
**Stack:** `mvp-data-wiring` (PR 9 of 10)
*Generated with [Claude Code](https://claude.com/claude-code)*