### PR TITLE
Github Adapter

### DIFF
--- a/app/backend/__tests__/molecules/test_github_adapter.py
+++ b/app/backend/__tests__/molecules/test_github_adapter.py
@@ -766,3 +766,186 @@ class TestDTOSerialization:
         d = fc.model_dump()
         assert d["language"] == "python"
         assert d["truncated"] is False
+
+
+# ---------------------------------------------------------------------------
+# GitHubAdapter.create_check_run
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterCreateCheckRun:
+    @pytest.mark.unit
+    async def test_sends_correct_payload(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["method"] = request.method
+            captured["body"] = request.content.decode()
+            return _make_response({"id": 101, "name": "cascade-gate", "status": "in_progress"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.create_check_run("myorg", "myrepo", "cascade-gate", "abc123sha")
+
+        assert "/repos/myorg/myrepo/check-runs" in str(captured["url"])
+        assert captured["method"] == "POST"
+        import json
+
+        body = json.loads(str(captured["body"]))
+        assert body["name"] == "cascade-gate"
+        assert body["head_sha"] == "abc123sha"
+        assert body["status"] == "in_progress"
+        assert result["id"] == 101
+
+    @pytest.mark.unit
+    async def test_raises_on_error(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=422, json={"message": "Validation failed"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubAPIError):
+            await adapter.create_check_run("o", "r", "name", "sha")
+
+
+# ---------------------------------------------------------------------------
+# GitHubAdapter.update_check_run
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterUpdateCheckRun:
+    @pytest.mark.unit
+    async def test_with_conclusion(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["method"] = request.method
+            captured["body"] = request.content.decode()
+            return _make_response({"id": 101, "status": "completed", "conclusion": "success"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        output = {"title": "Cascade OK", "summary": "All children merged"}
+        result = await adapter.update_check_run(
+            "myorg", "myrepo", 101, "completed", conclusion="success", output=output
+        )
+
+        assert "/repos/myorg/myrepo/check-runs/101" in str(captured["url"])
+        assert captured["method"] == "PATCH"
+        import json
+
+        body = json.loads(str(captured["body"]))
+        assert body["status"] == "completed"
+        assert body["conclusion"] == "success"
+        assert body["output"]["title"] == "Cascade OK"
+        assert result["id"] == 101
+
+    @pytest.mark.unit
+    async def test_without_conclusion_omits_it(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = request.content.decode()
+            return _make_response({"id": 101, "status": "in_progress"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        await adapter.update_check_run("o", "r", 101, "in_progress")
+
+        import json
+
+        body = json.loads(str(captured["body"]))
+        assert body["status"] == "in_progress"
+        assert "conclusion" not in body
+        assert "output" not in body
+
+    @pytest.mark.unit
+    async def test_raises_on_error(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=404, json={"message": "Not Found"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubNotFoundError):
+            await adapter.update_check_run("o", "r", 999, "completed", conclusion="failure")
+
+
+# ---------------------------------------------------------------------------
+# GitHubAdapter.retarget_pr
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterRetargetPR:
+    @pytest.mark.unit
+    async def test_sends_correct_base(self) -> None:
+        captured: dict[str, object] = {}
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["method"] = request.method
+            captured["body"] = request.content.decode()
+            return _make_response({"id": 42, "number": 42, "base": {"ref": "main"}})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.retarget_pr("myorg", "myrepo", 42, "main")
+
+        assert "/repos/myorg/myrepo/pulls/42" in str(captured["url"])
+        assert captured["method"] == "PATCH"
+        import json
+
+        body = json.loads(str(captured["body"]))
+        assert body["base"] == "main"
+        assert result["number"] == 42
+
+    @pytest.mark.unit
+    async def test_raises_on_404(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=404, json={"message": "Not Found"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubNotFoundError):
+            await adapter.retarget_pr("o", "r", 999, "main")
+
+
+# ---------------------------------------------------------------------------
+# GitHubAdapter.get_check_suites
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubAdapterGetCheckSuites:
+    @pytest.mark.unit
+    async def test_returns_check_suites_array(self) -> None:
+        suites_response = {
+            "total_count": 2,
+            "check_suites": [
+                {"id": 1, "app": {"slug": "github-actions"}, "status": "completed", "conclusion": "success"},
+                {"id": 2, "app": {"slug": "codecov"}, "status": "completed", "conclusion": "success"},
+            ],
+        }
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            assert "/commits/abc123/check-suites" in str(request.url)
+            return _make_response(suites_response)
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_suites("myorg", "myrepo", "abc123")
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+        assert result[1]["app"]["slug"] == "codecov"
+
+    @pytest.mark.unit
+    async def test_empty_check_suites(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return _make_response({"total_count": 0, "check_suites": []})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        result = await adapter.get_check_suites("o", "r", "sha1")
+        assert result == []
+
+    @pytest.mark.unit
+    async def test_raises_on_error(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=500, json={"message": "Server Error"})
+
+        adapter = _make_adapter(httpx.MockTransport(handler))
+        with pytest.raises(GitHubAPIError):
+            await adapter.get_check_suites("o", "r", "sha")

--- a/app/backend/__tests__/molecules/test_remote_restack.py
+++ b/app/backend/__tests__/molecules/test_remote_restack.py
@@ -24,10 +24,7 @@ from molecules.services.remote_restack import (
 
 def _make_branches(names: list[str]) -> list[dict]:
     """Build a branches list from names, assigning positions 1..N."""
-    return [
-        {"name": name, "position": i + 1, "head_sha": f"sha_{i}"}
-        for i, name in enumerate(names)
-    ]
+    return [{"name": name, "position": i + 1, "head_sha": f"sha_{i}"} for i, name in enumerate(names)]
 
 
 def _mock_clone_manager(clone_path: Path = Path("/tmp/fake-clone")) -> CloneManager:

--- a/app/backend/src/molecules/providers/github_adapter.py
+++ b/app/backend/src/molecules/providers/github_adapter.py
@@ -6,9 +6,8 @@ from pathlib import PurePosixPath
 from typing import Protocol
 
 import httpx
-from pydantic import BaseModel
-
 from pattern_stack.atoms.cache import get_cache
+from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
 # Protocol DTOs
@@ -462,9 +461,7 @@ class GitHubAdapter:
         data: dict[str, object] = response.json()
         return data
 
-    async def mark_pr_ready(
-        self, owner: str, repo: str, pr_number: int
-    ) -> None:
+    async def mark_pr_ready(self, owner: str, repo: str, pr_number: int) -> None:
         """Remove draft status from a pull request."""
         response = await self._client.patch(
             f"/repos/{owner}/{repo}/pulls/{pr_number}",
@@ -506,9 +503,7 @@ class GitHubAdapter:
         result: list[dict[str, object]] = response.json()
         return result
 
-    async def hydrate_stack(
-        self, owner: str, repo: str, branches: list[tuple[str, str, str]]
-    ) -> None:
+    async def hydrate_stack(self, owner: str, repo: str, branches: list[tuple[str, str, str]]) -> None:
         """Pre-load cache for an entire stack's diffs.
 
         Args:
@@ -518,6 +513,72 @@ class GitHubAdapter:
 
         tasks = [self.get_diff(owner, repo, base, head) for _, base, head in branches]
         await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def create_check_run(self, owner: str, repo: str, name: str, head_sha: str) -> dict[str, object]:
+        """Create a check run on a commit.
+
+        POST /repos/{owner}/{repo}/check-runs
+        Requires GitHub App installation token with checks:write permission.
+        """
+        response = await self._client.post(
+            f"/repos/{owner}/{repo}/check-runs",
+            json={"name": name, "head_sha": head_sha, "status": "in_progress"},
+        )
+        self._raise_for_status(response)
+        data: dict[str, object] = response.json()
+        return data
+
+    async def update_check_run(
+        self,
+        owner: str,
+        repo: str,
+        check_run_id: int,
+        status: str,
+        conclusion: str | None = None,
+        output: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        """Update a check run's status and conclusion.
+
+        PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}
+        Only includes non-None fields in the request body.
+        """
+        body: dict[str, object] = {"status": status}
+        if conclusion is not None:
+            body["conclusion"] = conclusion
+        if output is not None:
+            body["output"] = output
+        response = await self._client.patch(
+            f"/repos/{owner}/{repo}/check-runs/{check_run_id}",
+            json=body,
+        )
+        self._raise_for_status(response)
+        data: dict[str, object] = response.json()
+        return data
+
+    async def retarget_pr(self, owner: str, repo: str, pr_number: int, new_base: str) -> dict[str, object]:
+        """Change a PR's base branch.
+
+        PATCH /repos/{owner}/{repo}/pulls/{pr_number}
+        """
+        response = await self._client.patch(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}",
+            json={"base": new_base},
+        )
+        self._raise_for_status(response)
+        data: dict[str, object] = response.json()
+        return data
+
+    async def get_check_suites(self, owner: str, repo: str, ref: str) -> list[dict[str, object]]:
+        """Get all check suites for a commit ref.
+
+        GET /repos/{owner}/{repo}/commits/{ref}/check-suites
+        Returns the check_suites array from the response.
+        """
+        response = await self._client.get(f"/repos/{owner}/{repo}/commits/{ref}/check-suites")
+        self._raise_for_status(response)
+        data = response.json()
+        result: list[dict[str, object]] = data.get("check_suites", [])
+        return result
 
     async def get_check_status(self, owner: str, repo: str, ref: str) -> CheckStatusResult:
         """Get aggregated CI check status for a commit ref."""
@@ -556,9 +617,7 @@ class GitHubAdapter:
             else:
                 agg_status = "pass"
 
-            result = CheckStatusResult(
-                status=agg_status, total=total, passed=passed, failed=failed, pending=pending
-            )
+            result = CheckStatusResult(status=agg_status, total=total, passed=passed, failed=failed, pending=pending)
 
         await self._cache.set(cache_key, result.model_dump(), ttl=_CI_CACHE_TTL, namespace=_CACHE_NS)
         return result


### PR DESCRIPTION
## Summary
Extend `GitHubAdapter` with four new GitHub API methods needed for cascade gate automation: creating/updating check runs, retargeting PR base branches, and listing check suites on a commit.

## Changes
- Add `create_check_run` and `update_check_run` for posting cascade status checks to GitHub (checks:write permission required)
- Add `retarget_pr` to change a PR's base branch — key operation during stack rebase/reorder
- Add `get_check_suites` to inspect CI status on a given commit SHA
- 10 unit tests covering happy paths, optional field omission, and error propagation for all four methods

---
**Stack:** `merge-cascade` (PR 2 of 5)
*Generated with [Claude Code](https://claude.com/claude-code)*