### PR TITLE
Webhooks

### DIFF
--- a/app/backend/__tests__/molecules/test_webhook_dispatcher.py
+++ b/app/backend/__tests__/molecules/test_webhook_dispatcher.py
@@ -1,0 +1,249 @@
+"""Tests for WebhookDispatcher -- routes GitHub webhook events to domain handlers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_step(*, state: str = "ci_pending", head_sha: str = "abc123") -> MagicMock:
+    step = MagicMock()
+    step.id = uuid4()
+    step.cascade_id = uuid4()
+    step.branch_id = uuid4()
+    step.pull_request_id = uuid4()
+    step.state = state
+    step.head_sha = head_sha
+    step.check_run_external_id = 999
+    return step
+
+
+def _make_pr(*, external_id: int = 42, state: str = "open") -> MagicMock:
+    pr = MagicMock()
+    pr.id = uuid4()
+    pr.external_id = external_id
+    pr.state = state
+    return pr
+
+
+def _make_workspace(*, repo_url: str = "https://github.com/org/repo") -> MagicMock:
+    ws = MagicMock()
+    ws.id = uuid4()
+    ws.repo_url = repo_url
+    return ws
+
+
+def _make_branch(*, workspace_id=None) -> MagicMock:
+    branch = MagicMock()
+    branch.id = uuid4()
+    branch.workspace_id = workspace_id or uuid4()
+    return branch
+
+
+def _build_dispatcher():
+    """Build a WebhookDispatcher with all dependencies mocked."""
+    from molecules.services.webhook_dispatcher import WebhookDispatcher
+
+    cascade_workflow = AsyncMock()
+    cascade_step_service = AsyncMock()
+    pull_request_service = AsyncMock()
+    workspace_service = AsyncMock()
+    branch_service = AsyncMock()
+    db = AsyncMock()
+
+    dispatcher = WebhookDispatcher(
+        cascade_workflow=cascade_workflow,
+        cascade_step_service=cascade_step_service,
+        pull_request_service=pull_request_service,
+        workspace_service=workspace_service,
+        branch_service=branch_service,
+        db=db,
+    )
+    return (
+        dispatcher,
+        cascade_workflow,
+        cascade_step_service,
+        pull_request_service,
+        workspace_service,
+        branch_service,
+        db,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _handle_check_suite_completed: happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_check_suite_completed() -> None:
+    """Finds step by head_sha, evaluates, and advances cascade."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    step = _make_step(state="ci_pending", head_sha="sha_from_ci")
+    workspace = _make_workspace()
+    branch = _make_branch(workspace_id=workspace.id)
+
+    step_svc.get_by_head_sha.return_value = step
+    branch_svc.get.return_value = branch
+    ws_svc.get.return_value = workspace
+
+    # evaluate_step transitions to "completing" (PR merged by us)
+    evaluated_step = MagicMock()
+    evaluated_step.state = "completing"
+    evaluated_step.cascade_id = step.cascade_id
+    workflow.evaluate_step.return_value = evaluated_step
+
+    workflow.advance_cascade.return_value = None
+
+    payload = {
+        "action": "completed",
+        "check_suite": {"head_sha": "sha_from_ci", "conclusion": "success"},
+    }
+
+    result = await dispatcher.dispatch("check_suite", payload)
+
+    assert result["handled"] is True
+    workflow.evaluate_step.assert_called_once_with(db, step, workspace)
+    workflow.advance_cascade.assert_called_once_with(db, step.cascade_id, workspace)
+
+
+# ---------------------------------------------------------------------------
+# _handle_check_suite_completed: no matching step
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_check_suite_no_matching_step() -> None:
+    """Ignores gracefully when no cascade step matches the head_sha."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    step_svc.get_by_head_sha.return_value = None
+
+    payload = {
+        "action": "completed",
+        "check_suite": {"head_sha": "unknown_sha", "conclusion": "success"},
+    }
+
+    result = await dispatcher.dispatch("check_suite", payload)
+
+    assert result["handled"] is False
+    workflow.evaluate_step.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_check_suite_completed: step not in ci_pending state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_check_suite_step_not_ci_pending() -> None:
+    """Idempotent ignore when step is not in ci_pending state."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    step = _make_step(state="merged", head_sha="sha_already_done")
+    step_svc.get_by_head_sha.return_value = step
+
+    payload = {
+        "action": "completed",
+        "check_suite": {"head_sha": "sha_already_done", "conclusion": "success"},
+    }
+
+    result = await dispatcher.dispatch("check_suite", payload)
+
+    assert result["handled"] is False
+    workflow.evaluate_step.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_pull_request_merged: happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_pr_merged() -> None:
+    """Finds step by PR, completes step, advances cascade."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    pr = _make_pr(external_id=42)
+    step = _make_step(state="completing")
+    step.pull_request_id = pr.id
+    workspace = _make_workspace()
+    branch = _make_branch(workspace_id=workspace.id)
+
+    pr_svc.get_by_external_id.return_value = pr
+    step_svc.get_by_pull_request.return_value = step
+    branch_svc.get.return_value = branch
+    ws_svc.get.return_value = workspace
+
+    # entity.complete_step is called via workflow
+    workflow.entity = MagicMock()
+    workflow.entity.complete_step = AsyncMock(return_value=step)
+    workflow.advance_cascade.return_value = None
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"number": 42, "merged": True},
+    }
+
+    result = await dispatcher.dispatch("pull_request", payload)
+
+    assert result["handled"] is True
+    workflow.entity.complete_step.assert_called_once_with(db, step.id)
+    workflow.advance_cascade.assert_called_once_with(db, step.cascade_id, workspace)
+
+
+# ---------------------------------------------------------------------------
+# _handle_pull_request_merged: no matching PR
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_pr_merged_no_matching_pr() -> None:
+    """Ignores gracefully when no PR matches the external_id."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    pr_svc.get_by_external_id.return_value = None
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"number": 999, "merged": True},
+    }
+
+    result = await dispatcher.dispatch("pull_request", payload)
+
+    assert result["handled"] is False
+    workflow.entity.complete_step.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_pull_request_merged: step not in completing state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_handle_pr_merged_step_not_completing() -> None:
+    """Idempotent ignore when step is not in completing state."""
+    dispatcher, workflow, step_svc, pr_svc, ws_svc, branch_svc, db = _build_dispatcher()
+
+    pr = _make_pr(external_id=42)
+    step = _make_step(state="merged")  # Already done
+
+    pr_svc.get_by_external_id.return_value = pr
+    step_svc.get_by_pull_request.return_value = step
+
+    payload = {
+        "action": "closed",
+        "pull_request": {"number": 42, "merged": True},
+    }
+
+    result = await dispatcher.dispatch("pull_request", payload)
+
+    assert result["handled"] is False
+    workflow.entity.complete_step.assert_not_called()

--- a/app/backend/__tests__/organisms/test_webhooks.py
+++ b/app/backend/__tests__/organisms/test_webhooks.py
@@ -1,0 +1,216 @@
+"""Tests for webhook router -- HMAC verification and event dispatching."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from organisms.api.app import create_app
+from organisms.api.routers.webhooks import get_webhook_dispatcher
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TEST_SECRET = "test-webhook-secret-123"
+
+
+def _sign_payload(payload: bytes, secret: str) -> str:
+    """Create a valid HMAC-SHA256 signature for a payload."""
+    sig = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+    return f"sha256={sig}"
+
+
+def _make_test_app(*, dispatcher_mock: AsyncMock | None = None):
+    """Create a test app with dependency overrides to skip DB."""
+    app = create_app()
+
+    if dispatcher_mock is not None:
+        app.dependency_overrides[get_webhook_dispatcher] = lambda: dispatcher_mock
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Signature verification tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_webhook_signature_valid() -> None:
+    """Correct HMAC signature passes verification."""
+    payload = json.dumps({"action": "completed", "check_suite": {"head_sha": "abc"}}).encode()
+    signature = _sign_payload(payload, TEST_SECRET)
+
+    mock_dispatcher = AsyncMock()
+    mock_dispatcher.dispatch.return_value = {"handled": False, "reason": "unhandled event"}
+
+    app = _make_test_app(dispatcher_mock=mock_dispatcher)
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = TEST_SECRET
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": signature,
+                    "X-GitHub-Event": "check_suite",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+async def test_webhook_signature_invalid() -> None:
+    """Wrong signature returns 401."""
+    payload = json.dumps({"action": "completed"}).encode()
+    bad_signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+
+    # No dispatcher needed -- should reject before dispatch
+    app = _make_test_app(dispatcher_mock=AsyncMock())
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = TEST_SECRET
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": bad_signature,
+                    "X-GitHub-Event": "check_suite",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+async def test_webhook_empty_secret_rejected() -> None:
+    """Empty WEBHOOK_SECRET returns 500 -- don't silently accept."""
+    payload = json.dumps({"action": "completed"}).encode()
+
+    app = _make_test_app(dispatcher_mock=AsyncMock())
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = ""
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": "sha256=anything",
+                    "X-GitHub-Event": "check_suite",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Event dispatching tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_webhook_check_suite_completed_dispatched() -> None:
+    """check_suite event with completed action is dispatched."""
+    payload_dict = {"action": "completed", "check_suite": {"head_sha": "abc123"}}
+    payload = json.dumps(payload_dict).encode()
+    signature = _sign_payload(payload, TEST_SECRET)
+
+    mock_dispatcher = AsyncMock()
+    mock_dispatcher.dispatch.return_value = {"handled": True}
+
+    app = _make_test_app(dispatcher_mock=mock_dispatcher)
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = TEST_SECRET
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": signature,
+                    "X-GitHub-Event": "check_suite",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 200
+    mock_dispatcher.dispatch.assert_called_once_with("check_suite", payload_dict)
+
+
+@pytest.mark.unit
+async def test_webhook_pull_request_merged_dispatched() -> None:
+    """pull_request event with merged PR is dispatched."""
+    payload_dict = {
+        "action": "closed",
+        "pull_request": {"number": 42, "merged": True},
+    }
+    payload = json.dumps(payload_dict).encode()
+    signature = _sign_payload(payload, TEST_SECRET)
+
+    mock_dispatcher = AsyncMock()
+    mock_dispatcher.dispatch.return_value = {"handled": True}
+
+    app = _make_test_app(dispatcher_mock=mock_dispatcher)
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = TEST_SECRET
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": signature,
+                    "X-GitHub-Event": "pull_request",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 200
+    mock_dispatcher.dispatch.assert_called_once_with("pull_request", payload_dict)
+
+
+@pytest.mark.unit
+async def test_webhook_unhandled_event_ignored() -> None:
+    """Unknown event type returns 200 -- we always ack webhooks."""
+    payload_dict = {"action": "something"}
+    payload = json.dumps(payload_dict).encode()
+    signature = _sign_payload(payload, TEST_SECRET)
+
+    mock_dispatcher = AsyncMock()
+    mock_dispatcher.dispatch.return_value = {"handled": False, "reason": "unhandled event"}
+
+    app = _make_test_app(dispatcher_mock=mock_dispatcher)
+
+    with patch("organisms.api.routers.webhooks.get_settings") as mock_settings:
+        mock_settings.return_value.WEBHOOK_SECRET = TEST_SECRET
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/api/v1/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": signature,
+                    "X-GitHub-Event": "random_event",
+                    "Content-Type": "application/json",
+                },
+            )
+
+    assert response.status_code == 200

--- a/app/backend/src/molecules/services/webhook_dispatcher.py
+++ b/app/backend/src/molecules/services/webhook_dispatcher.py
@@ -1,0 +1,152 @@
+"""WebhookDispatcher -- routes GitHub webhook events to domain handlers.
+
+Lives at the molecule layer, composing feature services and the cascade
+workflow to handle check_suite.completed and pull_request.merged events.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from features.branches.service import BranchService
+    from features.cascade_steps.service import CascadeStepService
+    from features.pull_requests.service import PullRequestService
+    from features.workspaces.service import WorkspaceService
+    from molecules.workflows.cascade_workflow import CascadeWorkflow
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookDispatcher:
+    """Routes GitHub webhook events to the appropriate domain handler.
+
+    Composes CascadeWorkflow and feature services to handle:
+    - check_suite.completed: evaluate whether a cascade step can proceed
+    - pull_request.closed+merged: complete a cascade step and advance
+    """
+
+    def __init__(
+        self,
+        *,
+        cascade_workflow: CascadeWorkflow,
+        cascade_step_service: CascadeStepService,
+        pull_request_service: PullRequestService,
+        workspace_service: WorkspaceService,
+        branch_service: BranchService,
+        db: AsyncSession,
+    ) -> None:
+        self.cascade_workflow = cascade_workflow
+        self.cascade_step_service = cascade_step_service
+        self.pull_request_service = pull_request_service
+        self.workspace_service = workspace_service
+        self.branch_service = branch_service
+        self.db = db
+
+    async def dispatch(self, event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Route a webhook event to the appropriate handler.
+
+        Returns a result dict indicating whether the event was handled.
+        """
+        if event_type == "check_suite" and payload.get("action") == "completed":
+            return await self._handle_check_suite_completed(payload)
+
+        if (
+            event_type == "pull_request"
+            and payload.get("action") == "closed"
+            and payload.get("pull_request", {}).get("merged")
+        ):
+            return await self._handle_pull_request_merged(payload)
+
+        return {"handled": False, "reason": "unhandled event"}
+
+    async def _handle_check_suite_completed(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """External CI finished -- evaluate if cascade step can proceed.
+
+        1. Extract head_sha from payload
+        2. Find cascade step by head_sha
+        3. If no step found or not in ci_pending state, ignore (idempotent)
+        4. Get workspace for the step's branch
+        5. Call cascade_workflow.evaluate_step()
+        6. If step transitions to completing, advance cascade
+        """
+        head_sha = payload.get("check_suite", {}).get("head_sha")
+        if not head_sha:
+            return {"handled": False, "reason": "no head_sha in payload"}
+
+        step = await self.cascade_step_service.get_by_head_sha(self.db, head_sha)
+        if step is None:
+            logger.debug("No cascade step found for head_sha=%s", head_sha)
+            return {"handled": False, "reason": "no matching cascade step"}
+
+        if step.state != "ci_pending":
+            logger.debug("Step %s in state %s, not ci_pending -- ignoring", step.id, step.state)
+            return {"handled": False, "reason": f"step in state {step.state}"}
+
+        # Get workspace via branch
+        workspace = await self._get_workspace_for_step(step)
+        if workspace is None:
+            logger.warning("No workspace found for step %s", step.id)
+            return {"handled": False, "reason": "no workspace found"}
+
+        # Evaluate the step
+        evaluated = await self.cascade_workflow.evaluate_step(self.db, step, workspace)
+
+        # If step transitioned to completing (PR merged by us), advance cascade
+        if evaluated.state == "completing":
+            await self.cascade_workflow.advance_cascade(self.db, step.cascade_id, workspace)
+
+        return {"handled": True, "step_id": str(step.id), "new_state": evaluated.state}
+
+    async def _handle_pull_request_merged(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """PR was merged on GitHub -- complete cascade step and advance.
+
+        1. Extract PR number from payload
+        2. Find PullRequest by external_id
+        3. If not found, ignore
+        4. Find cascade step by pull_request_id
+        5. If no step or not in completing state, ignore (idempotent)
+        6. Call entity.complete_step()
+        7. Call cascade_workflow.advance_cascade()
+        """
+        pr_number = payload.get("pull_request", {}).get("number")
+        if pr_number is None:
+            return {"handled": False, "reason": "no PR number in payload"}
+
+        pr = await self.pull_request_service.get_by_external_id(self.db, pr_number)
+        if pr is None:
+            logger.debug("No local PR found for external_id=%s", pr_number)
+            return {"handled": False, "reason": "no matching pull request"}
+
+        step = await self.cascade_step_service.get_by_pull_request(self.db, pr.id)
+        if step is None:
+            logger.debug("No cascade step found for PR %s", pr.id)
+            return {"handled": False, "reason": "no matching cascade step"}
+
+        if step.state != "completing":
+            logger.debug("Step %s in state %s, not completing -- ignoring", step.id, step.state)
+            return {"handled": False, "reason": f"step in state {step.state}"}
+
+        # Get workspace via branch
+        workspace = await self._get_workspace_for_step(step)
+        if workspace is None:
+            logger.warning("No workspace found for step %s", step.id)
+            return {"handled": False, "reason": "no workspace found"}
+
+        # Complete the step
+        await self.cascade_workflow.entity.complete_step(self.db, step.id)
+
+        # Advance the cascade
+        await self.cascade_workflow.advance_cascade(self.db, step.cascade_id, workspace)
+
+        return {"handled": True, "step_id": str(step.id), "action": "completed_and_advanced"}
+
+    async def _get_workspace_for_step(self, step: Any) -> Any:
+        """Resolve the workspace for a cascade step via its branch."""
+        branch = await self.branch_service.get(self.db, step.branch_id)
+        if branch is None:
+            return None
+        return await self.workspace_service.get(self.db, branch.workspace_id)

--- a/app/backend/src/organisms/api/routers/webhooks.py
+++ b/app/backend/src/organisms/api/routers/webhooks.py
@@ -1,0 +1,96 @@
+"""Webhook router -- receives GitHub webhook events with HMAC verification."""
+
+import hashlib
+import hmac
+import json
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+
+from config.settings import get_settings
+from features.branches.service import BranchService
+from features.cascade_steps.service import CascadeStepService
+from features.pull_requests.service import PullRequestService
+from features.workspaces.service import WorkspaceService
+from molecules.entities.merge_cascade_entity import MergeCascadeEntity
+from molecules.services.webhook_dispatcher import WebhookDispatcher
+from molecules.workflows.cascade_workflow import CascadeWorkflow
+from organisms.api.dependencies import CloneManagerDep, DatabaseSession, GitHubAdapterDep
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/webhooks", tags=["webhooks"])
+
+
+def _verify_signature(payload_body: bytes, secret: str, signature_header: str) -> bool:
+    """Verify HMAC-SHA256 signature from GitHub."""
+    expected = "sha256=" + hmac.new(secret.encode(), payload_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def get_webhook_dispatcher(
+    db: DatabaseSession,
+    github: GitHubAdapterDep,
+    clone_manager: CloneManagerDep,
+) -> WebhookDispatcher:
+    """Build the webhook dispatcher with all its dependencies."""
+    entity = MergeCascadeEntity(db)
+    workflow = CascadeWorkflow(entity=entity, github=github, clone_manager=clone_manager)
+
+    return WebhookDispatcher(
+        cascade_workflow=workflow,
+        cascade_step_service=CascadeStepService(),
+        pull_request_service=PullRequestService(),
+        workspace_service=WorkspaceService(),
+        branch_service=BranchService(),
+        db=db,
+    )
+
+
+WebhookDispatcherDep = Annotated[WebhookDispatcher, Depends(get_webhook_dispatcher)]
+
+
+@router.post("/github")
+async def github_webhook(request: Request, dispatcher: WebhookDispatcherDep) -> JSONResponse:
+    """Receive GitHub webhook events.
+
+    1. Read raw body bytes (needed for HMAC verification)
+    2. Verify HMAC-SHA256 signature
+    3. Dispatch to handler based on event type
+    4. Return 200 OK (always, even if we ignore the event)
+    """
+    # 1. Read raw body
+    payload_body = await request.body()
+
+    # 2. Get signature header
+    signature_header = request.headers.get("X-Hub-Signature-256", "")
+
+    # 3. Get webhook secret
+    settings = get_settings()
+    webhook_secret = settings.WEBHOOK_SECRET
+
+    # 4. Reject if no secret configured (don't silently accept)
+    if not webhook_secret:
+        logger.error("WEBHOOK_SECRET is not configured -- rejecting webhook")
+        return JSONResponse(
+            status_code=500,
+            content={"error": "Webhook secret not configured"},
+        )
+
+    # 5. Verify HMAC signature
+    if not _verify_signature(payload_body, webhook_secret, signature_header):
+        return JSONResponse(
+            status_code=401,
+            content={"error": "Invalid signature"},
+        )
+
+    # 6. Parse event type and body
+    event_type = request.headers.get("X-GitHub-Event", "")
+    payload = json.loads(payload_body)
+
+    # 7. Dispatch
+    result = await dispatcher.dispatch(event_type, payload)
+
+    return JSONResponse(status_code=200, content=result)


### PR DESCRIPTION
## Summary
Add a GitHub webhook endpoint with HMAC-SHA256 signature verification and a `WebhookDispatcher` that routes `check_suite.completed` and `pull_request.closed` events into the cascade workflow engine.

## Changes
- Add `POST /api/v1/webhooks/github` router with HMAC-SHA256 signature verification (401 on invalid secret)
- Add `WebhookDispatcher` molecule that routes CI check results and merged PRs to `evaluate_step` / `advance_cascade` handlers
- Add 12 unit tests covering signature verification, happy paths, missing entities, and idempotent no-ops for already-processed states

---
**Stack:** `merge-cascade` (PR 4 of 5)
*Generated with [Claude Code](https://claude.com/claude-code)*