### PR TITLE
Endpoints

### DIFF
--- a/app/backend/__tests__/organisms/test_cascade_endpoints.py
+++ b/app/backend/__tests__/organisms/test_cascade_endpoints.py
@@ -1,0 +1,100 @@
+"""Tests for merge cascade REST endpoints on the stacks router."""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from organisms.api.app import app
+from organisms.api.dependencies import get_stack_api
+
+
+@pytest.fixture
+def stack_id():
+    return uuid4()
+
+
+@pytest.fixture
+def cascade_id():
+    return uuid4()
+
+
+@pytest.fixture
+def mock_stack_api():
+    """Override get_stack_api dependency to return a mock StackAPI."""
+    mock_api = AsyncMock()
+    mock_api.start_merge_cascade = AsyncMock(
+        return_value={
+            "cascade": {"id": str(uuid4()), "state": "running"},
+            "steps": [],
+        }
+    )
+    mock_api.get_cascade_detail = AsyncMock(
+        return_value={
+            "cascade": {"id": str(uuid4()), "state": "running"},
+            "steps": [],
+        }
+    )
+    mock_api.cancel_cascade = AsyncMock(
+        return_value={
+            "cascade": {"id": str(uuid4()), "state": "cancelled"},
+            "steps": [],
+        }
+    )
+
+    app.dependency_overrides[get_stack_api] = lambda: mock_api
+    yield mock_api
+    app.dependency_overrides.pop(get_stack_api, None)
+
+
+@pytest.mark.unit
+async def test_start_cascade_returns_201(stack_id, mock_stack_api) -> None:
+    """POST /{stack_id}/merge-cascade returns 201 and calls start_merge_cascade."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            f"/api/v1/stacks/{stack_id}/merge-cascade",
+            json={"merge_method": "squash"},
+        )
+    assert response.status_code == 201
+    mock_stack_api.start_merge_cascade.assert_awaited_once_with(stack_id, triggered_by="api")
+
+
+@pytest.mark.unit
+async def test_start_cascade_default_merge_method(stack_id, mock_stack_api) -> None:
+    """POST with empty body uses default merge_method."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            f"/api/v1/stacks/{stack_id}/merge-cascade",
+            json={},
+        )
+    assert response.status_code == 201
+    mock_stack_api.start_merge_cascade.assert_awaited_once()
+
+
+@pytest.mark.unit
+async def test_get_cascade_detail(stack_id, cascade_id, mock_stack_api) -> None:
+    """GET /{stack_id}/merge-cascade/{cascade_id} returns cascade detail."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get(f"/api/v1/stacks/{stack_id}/merge-cascade/{cascade_id}")
+    assert response.status_code == 200
+    mock_stack_api.get_cascade_detail.assert_awaited_once_with(cascade_id)
+
+
+@pytest.mark.unit
+async def test_cancel_cascade(stack_id, cascade_id, mock_stack_api) -> None:
+    """POST /{stack_id}/merge-cascade/{cascade_id}/cancel cancels cascade."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(f"/api/v1/stacks/{stack_id}/merge-cascade/{cascade_id}/cancel")
+    assert response.status_code == 200
+    mock_stack_api.cancel_cascade.assert_awaited_once_with(cascade_id)
+
+
+@pytest.mark.unit
+async def test_deprecated_merge_returns_410(stack_id, mock_stack_api) -> None:
+    """POST /{stack_id}/merge returns 410 Gone pointing to new endpoint."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(f"/api/v1/stacks/{stack_id}/merge")
+    assert response.status_code == 410
+    data = response.json()
+    assert "merge-cascade" in data["detail"]

--- a/app/backend/src/molecules/apis/stack_api.py
+++ b/app/backend/src/molecules/apis/stack_api.py
@@ -17,8 +17,10 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from features.review_comments.schemas.input import ReviewCommentCreate, ReviewCommentUpdate
+    from molecules.entities.merge_cascade_entity import MergeCascadeEntity
     from molecules.providers.github_adapter import DiffData, FileContent, FileTreeNode, GitHubAdapter
     from molecules.services.clone_manager import CloneManager
+    from molecules.workflows.cascade_workflow import CascadeWorkflow
 
 logger = logging.getLogger(__name__)
 
@@ -44,12 +46,16 @@ class StackAPI:
         db: AsyncSession,
         github: GitHubAdapter | None = None,
         clone_manager: CloneManager | None = None,
+        cascade_entity: MergeCascadeEntity | None = None,
+        cascade_workflow: CascadeWorkflow | None = None,
     ) -> None:
         self.db = db
         self.entity = StackEntity(db)
         self.github = github
         self.clone_manager = clone_manager
         self._comment_svc = ReviewCommentService()
+        self._cascade_entity = cascade_entity
+        self._cascade_workflow = cascade_workflow
 
     async def create_stack(
         self,
@@ -106,9 +112,11 @@ class StackAPI:
 
             if ci_tasks:
                 results = await asyncio.gather(*ci_tasks, return_exceptions=True)
-                for idx, result in zip(ci_indices, results):
+                for idx, result in zip(ci_indices, results, strict=True):
                     if isinstance(result, BaseException):
-                        logger.warning("Failed to fetch CI status for branch %s: %s", branches[idx]["branch"]["name"], result)
+                        logger.warning(
+                            "Failed to fetch CI status for branch %s: %s", branches[idx]["branch"]["name"], result
+                        )
                         branches[idx]["ci_status"] = "none"
                     else:
                         branches[idx]["ci_status"] = result.status
@@ -252,6 +260,56 @@ class StackAPI:
         await self.db.refresh(pr)
         return PullRequestResponse.model_validate(pr)
 
+    # --- Merge cascade ---
+
+    async def start_merge_cascade(self, stack_id: UUID, triggered_by: str) -> dict:
+        """Start a merge cascade.
+
+        1. Create cascade via entity.create_cascade(db, stack_id, triggered_by)
+        2. Get the first pending step
+        3. Get workspace for the stack
+        4. Process the first step via workflow.process_step(db, cascade_id, step, workspace)
+        5. Return cascade detail
+        """
+        if self._cascade_entity is None or self._cascade_workflow is None:
+            msg = "Cascade entity/workflow not configured"
+            raise RuntimeError(msg)
+
+        cascade = await self._cascade_entity.create_cascade(self.db, stack_id, triggered_by)
+
+        # Get the first pending step
+        from features.cascade_steps.service import CascadeStepService
+
+        step_svc = CascadeStepService()
+        first_step = await step_svc.get_pending_step(self.db, cascade.id)
+
+        if first_step is not None:
+            # Resolve workspace from first branch
+            branch = await self.entity.branch_service.get(self.db, first_step.branch_id)
+            if branch is not None:
+                workspace = await self.entity.workspace_service.get(self.db, branch.workspace_id)
+                if workspace is not None:
+                    await self._cascade_workflow.process_step(self.db, cascade.id, first_step, workspace)
+
+        await self.db.commit()
+        return await self._cascade_entity.get_cascade_detail(self.db, cascade.id)
+
+    async def get_cascade_detail(self, cascade_id: UUID) -> dict:
+        """Delegate to entity.get_cascade_detail."""
+        if self._cascade_entity is None:
+            msg = "Cascade entity not configured"
+            raise RuntimeError(msg)
+        return await self._cascade_entity.get_cascade_detail(self.db, cascade_id)
+
+    async def cancel_cascade(self, cascade_id: UUID) -> dict:
+        """Cancel a running cascade, return detail."""
+        if self._cascade_entity is None:
+            msg = "Cascade entity not configured"
+            raise RuntimeError(msg)
+        await self._cascade_entity.cancel_cascade(self.db, cascade_id)
+        await self.db.commit()
+        return await self._cascade_entity.get_cascade_detail(self.db, cascade_id)
+
     # --- Review comments (Stack Bench local, GitHub sync optional) ---
 
     async def create_comment(self, data: ReviewCommentCreate) -> ReviewCommentResponse:
@@ -288,10 +346,12 @@ class StackAPI:
         for bd in result["branches"]:
             branch_resp = BranchResponse.model_validate(bd["branch"])
             pr_resp = PullRequestResponse.model_validate(bd["pull_request"]) if bd["pull_request"] else None
-            synced.append({
-                "branch": branch_resp.model_dump(),
-                "pull_request": pr_resp.model_dump() if pr_resp else None,
-            })
+            synced.append(
+                {
+                    "branch": branch_resp.model_dump(),
+                    "pull_request": pr_resp.model_dump() if pr_resp else None,
+                }
+            )
         return {
             "branches": synced,
             "synced_count": result["synced_count"],
@@ -334,11 +394,13 @@ class StackAPI:
         for bd in branch_data:
             branch = bd["branch"]
             if branch.position >= from_position:
-                branches_input.append({
-                    "name": branch.name,
-                    "position": branch.position,
-                    "head_sha": branch.head_sha,
-                })
+                branches_input.append(
+                    {
+                        "name": branch.name,
+                        "position": branch.position,
+                        "head_sha": branch.head_sha,
+                    }
+                )
 
         # Run the restack
         svc = RemoteRestackService(self.clone_manager)

--- a/app/backend/src/organisms/api/app.py
+++ b/app/backend/src/organisms/api/app.py
@@ -12,6 +12,7 @@ from organisms.api.routers.agents import router as agents_router
 from organisms.api.routers.conversations import router as conversations_router
 from organisms.api.routers.projects import router as projects_router
 from organisms.api.routers.stacks import router as stacks_router
+from organisms.api.routers.webhooks import router as webhooks_router
 
 
 @asynccontextmanager
@@ -51,6 +52,7 @@ def create_app() -> FastAPI:
     app.include_router(agents_router, prefix="/api/v1")
     app.include_router(projects_router, prefix="/api/v1")
     app.include_router(stacks_router, prefix="/api/v1")
+    app.include_router(webhooks_router, prefix="/api/v1")
 
     # Error handlers
     app.add_exception_handler(MoleculeError, molecule_exception_handler)  # type: ignore[arg-type]

--- a/app/backend/src/organisms/api/dependencies.py
+++ b/app/backend/src/organisms/api/dependencies.py
@@ -8,9 +8,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config.settings import get_settings
 from molecules.apis.conversation_api import ConversationAPI
 from molecules.apis.stack_api import StackAPI
+from molecules.entities.merge_cascade_entity import MergeCascadeEntity
 from molecules.providers.github_adapter import GitHubAdapter
 from molecules.runtime.conversation_runner import ConversationRunner
 from molecules.services.clone_manager import CloneManager
+from molecules.workflows.cascade_workflow import CascadeWorkflow
 
 
 async def get_db(request: Request) -> AsyncGenerator[AsyncSession, None]:
@@ -58,8 +60,36 @@ def get_clone_manager() -> CloneManager:
 CloneManagerDep = Annotated[CloneManager, Depends(get_clone_manager)]
 
 
-def get_stack_api(db: DatabaseSession, github: GitHubAdapterDep, clone_manager: CloneManagerDep) -> StackAPI:
-    return StackAPI(db, github, clone_manager=clone_manager)
+def get_cascade_entity(db: DatabaseSession) -> MergeCascadeEntity:
+    return MergeCascadeEntity(db)
+
+
+CascadeEntityDep = Annotated[MergeCascadeEntity, Depends(get_cascade_entity)]
+
+
+def get_cascade_workflow(
+    entity: CascadeEntityDep, github: GitHubAdapterDep, clone_manager: CloneManagerDep
+) -> CascadeWorkflow:
+    return CascadeWorkflow(entity=entity, github=github, clone_manager=clone_manager)
+
+
+CascadeWorkflowDep = Annotated[CascadeWorkflow, Depends(get_cascade_workflow)]
+
+
+def get_stack_api(
+    db: DatabaseSession,
+    github: GitHubAdapterDep,
+    clone_manager: CloneManagerDep,
+    cascade_entity: CascadeEntityDep,
+    cascade_workflow: CascadeWorkflowDep,
+) -> StackAPI:
+    return StackAPI(
+        db,
+        github,
+        clone_manager=clone_manager,
+        cascade_entity=cascade_entity,
+        cascade_workflow=cascade_workflow,
+    )
 
 
 StackAPIDep = Annotated[StackAPI, Depends(get_stack_api)]

--- a/app/backend/src/organisms/api/routers/stacks.py
+++ b/app/backend/src/organisms/api/routers/stacks.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from features.branches.schemas.output import BranchResponse
@@ -134,13 +135,56 @@ async def restack_stack(stack_id: UUID, data: RestackRequest, api: StackAPIDep) 
     return await api.restack(stack_id, from_position=data.from_position)
 
 
-# --- Merge endpoint ---
+# --- Merge endpoint (deprecated) ---
 
 
-@router.post("/{stack_id}/merge")
-async def merge_stack(stack_id: UUID, api: StackAPIDep) -> dict[str, object]:
-    """Merge all PRs in the stack bottom-up via GitHub API."""
-    return await api.merge_stack(stack_id)
+@router.post("/{stack_id}/merge", deprecated=True)
+async def merge_stack(stack_id: UUID, api: StackAPIDep) -> JSONResponse:
+    """Deprecated: Use POST /{stack_id}/merge-cascade instead."""
+    return JSONResponse(
+        status_code=410,
+        content={"detail": "Use POST /stacks/{stack_id}/merge-cascade instead"},
+    )
+
+
+# --- Merge Cascade endpoints ---
+
+
+class StartCascadeRequest(BaseModel):
+    merge_method: str = Field("squash", max_length=20)
+
+
+@router.post("/{stack_id}/merge-cascade", status_code=201)
+async def start_merge_cascade(
+    stack_id: UUID,
+    data: StartCascadeRequest,
+    api: StackAPIDep,
+) -> dict[str, object]:
+    """Start a merge cascade for the stack.
+
+    Creates cascade + steps, processes first step (retarget, rebase, check run).
+    """
+    return await api.start_merge_cascade(stack_id, triggered_by="api")
+
+
+@router.get("/{stack_id}/merge-cascade/{cascade_id}")
+async def get_merge_cascade(
+    stack_id: UUID,
+    cascade_id: UUID,
+    api: StackAPIDep,
+) -> dict[str, object]:
+    """Get cascade status with all steps."""
+    return await api.get_cascade_detail(cascade_id)
+
+
+@router.post("/{stack_id}/merge-cascade/{cascade_id}/cancel")
+async def cancel_merge_cascade(
+    stack_id: UUID,
+    cascade_id: UUID,
+    api: StackAPIDep,
+) -> dict[str, object]:
+    """Cancel a running cascade."""
+    return await api.cancel_cascade(cascade_id)
 
 
 # --- Branch endpoints (nested under stack) ---


### PR DESCRIPTION
## Summary
Wire the merge cascade feature into the FastAPI layer by adding three REST endpoints to the stacks router, deprecating the old `/merge` endpoint, and threading `MergeCascadeEntity` and `CascadeWorkflow` through the dependency injection system.

## Changes
- Add `POST /{stack_id}/merge-cascade`, `GET /{stack_id}/merge-cascade/{cascade_id}`, and `POST /{stack_id}/merge-cascade/{cascade_id}/cancel` endpoints to the stacks router
- Deprecate `POST /{stack_id}/merge` with a 410 Gone response pointing to the new endpoint
- Inject `MergeCascadeEntity` and `CascadeWorkflow` into `StackAPI` via `get_stack_api` dependency, implementing `start_merge_cascade`, `get_cascade_detail`, and `cancel_cascade` on the API class
- Register the webhooks router in `app.py` (carried forward from prior PR in stack)
- Add 5 endpoint tests covering start, default merge method, detail fetch, cancel, and the 410 deprecation response

---
**Stack:** `merge-cascade` (PR 5 of 5)
*Generated with [Claude Code](https://claude.com/claude-code)*