### PR TITLE
docs(spec): agentic-tui standalone package extraction plan

### DIFF
--- a/.claude/specs/2026-04-03-embedded-browser-tabs.md
+++ b/.claude/specs/2026-04-03-embedded-browser-tabs.md
@@ -1,0 +1,563 @@
+---
+title: Embedded Browser Panel & Tabbed Content Area
+status: draft
+created: 2026-04-03
+branch:
+stack:
+stack_index:
+depends_on:
+---
+
+# Embedded Browser Panel & Tabbed Content Area
+
+## Problem
+
+The Stack Bench main content area currently switches between two views controlled by the sidebar mode toggle (`SidebarMode: "diffs" | "files"`). The toggle lives in the sidebar and swaps both the sidebar tree view and the main content in lockstep. There is no way to view a web page alongside diffs or code, and no concept of independent content tabs.
+
+For a developer workbench, being able to preview a deployed PR, check a staging environment, or view documentation without leaving the app is essential. The current architecture has no extension point for adding new content panel types beyond diffs and file viewing.
+
+## Solution
+
+Add a tabbed content area to the main panel (between PRHeader and the content viewport) and introduce a new "Browser" tab that renders an iframe-based web viewer. The three tabs are:
+
+1. **Stack Diffs** -- the existing `FilesChangedPanel` diff review (current default)
+2. **Code** -- the existing `FileContent` file viewer (currently triggered by sidebar "Files" mode)
+3. **Browser** -- a new embedded iframe panel for rendering web pages
+
+### Key Design Decisions
+
+**Tabs control the main content area independently from the sidebar.** The sidebar mode toggle (`Diffs | Files`) controls which tree view appears in the sidebar. The content tabs control what renders in the main viewport. This decouples sidebar navigation from content display -- you can browse the file tree in the sidebar while viewing a diff, or view the diff file list while previewing a URL in the browser.
+
+**Iframe-based browser for web-first.** The simplest approach that works today in any React web app. No Electron, Tauri, or native dependencies. The iframe loads any URL the host browser can reach, subject to standard same-origin/CORS/X-Frame-Options restrictions. Most internal tools, staging deployments, and localhost servers will work. Sites that set `X-Frame-Options: DENY` or `Content-Security-Policy: frame-ancestors 'none'` will not render. **Note:** the `<iframe>` `onError` event does *not* fire for X-Frame-Options/CSP blocks — the iframe loads blank and `onLoad` still fires. Reliable detection of frame-blocking is not possible in web mode; the BrowserPanel should show a generic "page may not support embedding" hint with an "Open in new tab" link, rather than claiming to detect the error. This limitation goes away in Tauri/WKWebView mode.
+
+**Future path to native macOS.** When Stack Bench becomes a Tauri desktop app, the iframe can be swapped for a Tauri `<webview>` backed by WKWebView, which bypasses iframe restrictions entirely. The component boundary (`BrowserPanel`) is designed as a seam for this swap -- the rest of the app talks to it via props (`url`, `onNavigate`, `onLoad`, `onError`), not iframe-specific APIs.
+
+## Current State
+
+### Layout hierarchy (AppShell.tsx)
+
+```
+<div class="flex h-screen">
+  <StackSidebar />            <!-- 320px fixed left -->
+  <main class="flex-1 flex flex-col">
+    <PRHeader />              <!-- fixed header -->
+    <div class="flex-1 overflow-auto">
+      {children}              <!-- content: FilesChangedPanel or FileContent -->
+    </div>
+  </main>
+  <AgentPanel />              <!-- collapsible right panel -->
+</div>
+```
+
+### Content switching (App.tsx, lines 267-303)
+
+Content is driven by `sidebarMode` state:
+- `sidebarMode === "diffs"` renders `<FilesChangedPanel />`
+- `sidebarMode === "files"` renders `<PathBar /> + <FileContent />`
+
+Both sidebar tree and main content change together. There is no tab bar -- the sidebar toggle is the only control.
+
+### Existing Tab atom
+
+The codebase already has a `Tab` atom (`components/atoms/Tab/Tab.tsx`) and a `CountBadge` companion. The `Tab` atom renders a button with `role="tab"`, `aria-selected`, and an underline border for the active state. It is not currently used anywhere in the app (the original TabBar from SB-038 was replaced by the sidebar mode toggle in the sidebar-layout-merge spec).
+
+## Architecture
+
+### New type: `ContentTab`
+
+```ts
+// types/content.ts
+export type ContentTab = "diffs" | "code" | "browser";
+```
+
+This is distinct from `SidebarMode` (which remains `"diffs" | "files"`). The sidebar mode controls sidebar tree display. The content tab controls main viewport content.
+
+### Replace existing `TabBar` molecule with `ContentTabBar`
+
+**Layer:** Molecule (composes Tab atoms with state management)
+
+The codebase already has a `TabBar` molecule at `components/molecules/TabBar/TabBar.tsx` that composes the same `Tab` and `CountBadge` atoms. It is currently unused (the original SB-038 TabBar was replaced by the sidebar mode toggle). Rather than creating a duplicate, **delete the existing `TabBar` directory** and create `ContentTabBar` as its replacement. The new molecule adds trailing content support (URL input) that the old `TabBar` lacked.
+
+A horizontal tab bar that renders inside `<main>`, between `PRHeader` and the content viewport. Uses the existing `Tab` atom and `CountBadge`.
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ PRHeader                                                    │
+├────────────────────────────────────────────────────────────┤
+│ [Stack Diffs (12)] [Code] [Browser]              [url bar]  │
+├────────��────────────────────────────��──────────────────────┤
+│                                                              │
+│  Content viewport (scrollable)                              │
+│                                                              │
+└────────��───────────────────────────────────────────────────┘
+```
+
+Props:
+```ts
+interface ContentTabBarProps {
+  activeTab: ContentTab;
+  onTabChange: (tab: ContentTab) => void;
+  diffFileCount?: number;
+  browserUrl?: string;
+  onBrowserUrlChange?: (url: string) => void;
+  onBrowserUrlSubmit?: () => void;
+}
+```
+
+The tab bar shows:
+- "Stack Diffs" with a `CountBadge` showing the changed file count
+- "Code" (plain label)
+- "Browser" (plain label)
+
+When the Browser tab is active, a compact URL input field appears inline to the right of the tabs, allowing the user to type or paste a URL and press Enter to navigate.
+
+### New organism: `BrowserPanel`
+
+**Layer:** Organism (interface component, thin wrapper over an iframe)
+
+Renders an iframe that loads the provided URL. Handles loading state, error detection, and URL bar integration.
+
+Props:
+```ts
+interface BrowserPanelProps {
+  url: string;
+  onNavigate?: (url: string) => void;
+  onLoad?: () => void;
+  onError?: (error: string) => void;
+}
+```
+
+Internal structure:
+- An `<iframe>` that fills the content viewport (`width: 100%, height: 100%`)
+- A loading spinner overlay while the iframe loads
+- Error/unloadable state: show a fallback with the URL and an "Open in new tab" link. Note: iframe `onError` does not fire for X-Frame-Options/CSP blocks, so this is best-effort — show the hint after a timeout or when the user reports the page is blank
+- The iframe uses `sandbox="allow-scripts allow-same-origin allow-forms allow-popups"` for reasonable security defaults
+
+### New atom: `UrlInput`
+
+**Layer:** Atom (pure visual input with submit behavior)
+
+A compact, inline URL input field styled to match the design system. Shows a globe/link icon prefix, the URL text, and submits on Enter.
+
+```ts
+interface UrlInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  placeholder?: string;
+  className?: string;
+}
+```
+
+### New icon additions
+
+The `Icon` atom needs two new icons:
+- `globe` -- for the URL input prefix and Browser tab
+- `code` -- for the Code tab (currently no code-specific icon exists; `file` is available but `code` with angle brackets is more semantic)
+
+## Component Hierarchy
+
+```
+AppShell (template)
+  StackSidebar (organism) -- unchanged
+  <main>
+    PRHeader (molecule) -- unchanged
+    ContentTabBar (molecule) -- NEW
+      Tab (atom) -- existing, reused
+      CountBadge (atom) -- existing, reused
+      UrlInput (atom) -- NEW (shown when browser tab active)
+    <content viewport>
+      FilesChangedPanel (organism) -- existing, shown when tab=diffs
+      PathBar + FileContent (molecules) -- existing, shown when tab=code
+      BrowserPanel (organism) -- NEW, shown when tab=browser
+    </content viewport>
+  </main>
+  AgentPanel (organism) -- unchanged
+```
+
+## Decoupling Sidebar Mode from Content Tab
+
+Today `sidebarMode` drives both sidebar tree and main content. After this change:
+
+| State | Sidebar tree | Main content |
+|-------|-------------|--------------|
+| `sidebarMode=diffs`, `contentTab=diffs` | Diff file list | FilesChangedPanel |
+| `sidebarMode=diffs`, `contentTab=code` | Diff file list | FileContent (last selected file) |
+| `sidebarMode=diffs`, `contentTab=browser` | Diff file list | BrowserPanel |
+| `sidebarMode=files`, `contentTab=diffs` | Full file tree | FilesChangedPanel |
+| `sidebarMode=files`, `contentTab=code` | Full file tree | FileContent |
+| `sidebarMode=files`, `contentTab=browser` | Full file tree | BrowserPanel |
+
+The sidebar file selection behavior stays the same: clicking a file in the diff list or file tree sets `selectedPath`. If the user is on the Code tab, the clicked file renders immediately. If they are on the Diffs tab, the diff scrolls to that file. The Browser tab is independent of file selection.
+
+**Backward compatibility:** When `contentTab` is `diffs` and `sidebarMode` is `diffs`, the behavior is identical to today. The default state on page load is `contentTab=diffs`, `sidebarMode=diffs`.
+
+**Smart tab switching:** Clicking a file in the sidebar when the Code tab is not active could optionally switch to the Code tab. This is a UX question addressed in Open Questions.
+
+## Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+Shift+1` / `Ctrl+Shift+1` | Switch to Stack Diffs tab |
+| `Cmd+Shift+2` / `Ctrl+Shift+2` | Switch to Code tab |
+| `Cmd+Shift+3` / `Ctrl+Shift+3` | Switch to Browser tab |
+| `Cmd+L` / `Ctrl+L` | Focus browser URL bar (when on Browser tab) |
+
+**Why `Cmd+Shift+N` instead of `Cmd+N`?** In browser mode, `Cmd+1/2/3` are consumed by the browser chrome (tab switching) before the page's `keydown` listener fires. `Cmd+Shift+1/2/3` avoids this conflict. When Stack Bench runs as a Tauri desktop app, we can reclaim `Cmd+1/2/3` since there are no browser chrome shortcuts to conflict with.
+
+These are implemented via a `useEffect` with `keydown` listener in `AuthenticatedApp`, following the same pattern as other keyboard handlers in the app.
+
+## Implementation Phases
+
+| Phase | What | Depends On |
+|-------|------|------------|
+| 1 | Types + ContentTabBar molecule | -- |
+| 2 | Decouple sidebar mode from content tab in App.tsx and AppShell | Phase 1 |
+| 3 | BrowserPanel organism + UrlInput atom | Phase 1 |
+| 4 | Keyboard shortcuts + polish | Phase 2, Phase 3 |
+
+## Phase Details
+
+### Phase 1: Types + ContentTabBar molecule
+
+Create the `ContentTab` type and the `ContentTabBar` molecule. Add the `globe` and `code` icons to the Icon atom.
+
+#### File: `app/frontend/src/types/content.ts` (new)
+
+```ts
+export type ContentTab = "diffs" | "code" | "browser";
+```
+
+#### File: `app/frontend/src/components/atoms/Icon/Icon.tsx` (modify)
+
+Add two new icon path entries to `iconPaths`:
+
+- `globe`: a circle with meridian/equator lines (standard Lucide globe icon)
+- `code`: angle brackets `< />` (standard Lucide code icon)
+
+#### File: `app/frontend/src/components/atoms/UrlInput/UrlInput.tsx` (new)
+
+A compact inline input with:
+- Globe icon prefix (`Icon name="globe" size="xs"`)
+- Text input with `type="url"`, monospace font
+- `onKeyDown` handler: Enter triggers `onSubmit`
+- Styling: `bg-[var(--bg-inset)]`, `border border-[var(--border)]`, `rounded-md`, `h-7`, `text-xs`, `font-[var(--font-mono)]`
+- Takes up remaining horizontal space in the tab bar (flex-1) when visible
+
+#### File: `app/frontend/src/components/atoms/UrlInput/index.ts` (new)
+
+Barrel export.
+
+#### File: `app/frontend/src/components/atoms/index.ts` (modify)
+
+Add `UrlInput` export.
+
+#### File: `app/frontend/src/components/molecules/ContentTabBar/ContentTabBar.tsx` (new)
+
+Renders a `<div role="tablist">` with three `Tab` atoms:
+- "Stack Diffs" -- `Icon name="git-commit" size="xs"` + label + `CountBadge` with `diffFileCount`
+- "Code" -- `Icon name="code" size="xs"` + label
+- "Browser" -- `Icon name="globe" size="xs"` + label
+
+When `activeTab === "browser"`, render `<UrlInput>` after the tabs, filling remaining width.
+
+Styling: `flex items-center gap-0 px-4 border-b border-[var(--border)] bg-[var(--bg-surface)]`. Tab bar height matches PRHeader bottom toolbar row aesthetic.
+
+#### File: `app/frontend/src/components/molecules/ContentTabBar/index.ts` (new)
+
+Barrel export.
+
+#### File: `app/frontend/src/components/molecules/index.ts` (modify)
+
+Add `ContentTabBar` export.
+
+#### Files summary
+
+| File | Action |
+|------|--------|
+| `src/types/content.ts` | Create |
+| `src/components/atoms/Icon/Icon.tsx` | Modify (add 2 icons) |
+| `src/components/atoms/UrlInput/UrlInput.tsx` | Create |
+| `src/components/atoms/UrlInput/index.ts` | Create |
+| `src/components/atoms/index.ts` | Modify (add UrlInput export) |
+| `src/components/molecules/TabBar/` | **Delete** (unused, replaced by ContentTabBar) |
+| `src/components/molecules/ContentTabBar/ContentTabBar.tsx` | Create |
+| `src/components/molecules/ContentTabBar/index.ts` | Create |
+| `src/components/molecules/index.ts` | Modify (remove TabBar export, add ContentTabBar) |
+
+---
+
+### Phase 2: Decouple sidebar mode from content tab
+
+Introduce `contentTab` state in `AuthenticatedApp`, wire it through `AppShell`, and render `ContentTabBar` in the main area. The sidebar mode toggle continues to control sidebar trees independently.
+
+#### File: `app/frontend/src/App.tsx` (modify)
+
+Changes to `AuthenticatedApp`:
+
+1. Add state: `const [contentTab, setContentTab] = useState<ContentTab>("diffs");`
+2. Add state: `const [browserUrl, setBrowserUrl] = useState("http://localhost:3000");`
+3. Pass `contentTab`, `onContentTabChange`, `browserUrl`, `onBrowserUrlChange`, `diffFileCount` to `AppShell`
+4. Change the children rendering logic:
+   - Current: switches on `sidebarMode`
+   - New: switches on `contentTab`
+     - `contentTab === "diffs"` -- render `FilesChangedPanel` (same as today)
+     - `contentTab === "code"` -- render `PathBar + FileContent` (same as today's `sidebarMode === "files"` content)
+     - `contentTab === "browser"` -- render `BrowserPanel`
+
+5. **Fix `useFileContent` hook gating.** Currently (line ~120) the hook is gated on `sidebarMode === "files"`:
+   ```ts
+   useFileContent(stackId, activeBranchId, sidebarMode === "files" ? selectedPath : null)
+   ```
+   Change this to gate on `contentTab === "code"`:
+   ```ts
+   useFileContent(stackId, activeBranchId, contentTab === "code" ? selectedPath : null)
+   ```
+   Without this change, the Code tab would show "Select a file" even when `selectedPath` is set.
+
+6. **Iframe mount/persist strategy.** Add a `hasActivatedBrowser` boolean state (`useState(false)`, set to `true` when `contentTab` first becomes `"browser"`). Render BrowserPanel using visibility rather than conditional mounting:
+   ```tsx
+   {/* BrowserPanel: mount on first activation, then persist with display:none */}
+   {hasActivatedBrowser && (
+     <div style={{ display: contentTab === "browser" ? "contents" : "none" }}>
+       <BrowserPanel url={browserUrl} ... />
+     </div>
+   )}
+   ```
+   This avoids reloading the iframe every time the user switches tabs. The `hasActivatedBrowser` guard ensures we don't load the iframe until the user first clicks the Browser tab.
+
+7. **PRHeader toolbar visibility.** The PRHeader toolbar (expand/collapse all, comment mode toggle) is diff-specific. Conditionally render the toolbar row only when `contentTab === "diffs"`. Pass `contentTab` to AppShell/PRHeader or use a `showToolbar` boolean prop.
+
+8. The `sidebarMode` state remains and continues to control sidebar tree display. Remove the coupling where `sidebarMode` also controlled main content.
+
+#### File: `app/frontend/src/components/templates/AppShell/AppShell.tsx` (modify)
+
+Changes to `AppShellProps`:
+- Add: `contentTab?: ContentTab`
+- Add: `onContentTabChange?: (tab: ContentTab) => void`
+- Add: `browserUrl?: string`
+- Add: `onBrowserUrlChange?: (url: string) => void`
+- Add: `onBrowserUrlSubmit?: () => void`
+- Add: `diffFileCount?: number` (already passed as `fileCount`, may reuse)
+
+In the render, insert `<ContentTabBar>` between `<PRHeader>` and the content viewport `<div>`:
+
+```tsx
+<main className="flex-1 flex flex-col min-w-0">
+  {/* PRHeader -- unchanged */}
+  {isEmpty ? <PRHeaderEmpty /> : <PRHeader ... />}
+
+  {/* NEW: Content tab bar */}
+  {!isEmpty && contentTab && onContentTabChange && (
+    <ContentTabBar
+      activeTab={contentTab}
+      onTabChange={onContentTabChange}
+      diffFileCount={diffFileCount}
+      browserUrl={browserUrl}
+      onBrowserUrlChange={onBrowserUrlChange}
+      onBrowserUrlSubmit={onBrowserUrlSubmit}
+    />
+  )}
+
+  {/* Content viewport -- unchanged structure, children now tab-driven */}
+  <div className="flex-1 overflow-auto">
+    {children}
+  </div>
+</main>
+```
+
+#### Files summary
+
+| File | Action |
+|------|--------|
+| `src/App.tsx` | Modify (add contentTab state, change content switching, fix useFileContent gating, iframe persist) |
+| `src/components/templates/AppShell/AppShell.tsx` | Modify (add ContentTabBar, new props, conditional PRHeader toolbar) |
+
+---
+
+### Phase 3: BrowserPanel organism + UrlInput atom
+
+Build the embedded browser panel.
+
+#### File: `app/frontend/src/components/organisms/BrowserPanel/BrowserPanel.tsx` (new)
+
+Structure:
+```tsx
+function BrowserPanel({ url, onNavigate, onLoad, onError }: BrowserPanelProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Reset loading state when URL changes
+  useEffect(() => {
+    setLoading(true);
+    setLoadError(false);
+  }, [url]);
+
+  return (
+    <div className="relative w-full h-full bg-[var(--bg-canvas)]">
+      {loading && <LoadingOverlay />}
+      {loadError ? (
+        <BrowserErrorState url={url} />
+      ) : (
+        <iframe
+          ref={iframeRef}
+          src={url}
+          className="w-full h-full border-0"
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+          onLoad={() => { setLoading(false); onLoad?.(); }}
+          onError={() => { setLoading(false); setLoadError(true); onError?.("Failed to load"); }}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+Internal components (in the same file, not exported):
+- `LoadingOverlay`: centered spinner/skeleton over the iframe area, absolute positioned, fades out on load
+- `BrowserErrorState`: centered message showing the URL, an explanation that the site may block embedding, and a "Open in new tab" link (`<a href={url} target="_blank">`)
+
+#### File: `app/frontend/src/components/organisms/BrowserPanel/index.ts` (new)
+
+Barrel export.
+
+#### File: `app/frontend/src/components/organisms/index.ts` (modify)
+
+Add `BrowserPanel` export.
+
+#### Files summary
+
+| File | Action |
+|------|--------|
+| `src/components/organisms/BrowserPanel/BrowserPanel.tsx` | Create |
+| `src/components/organisms/BrowserPanel/index.ts` | Create |
+| `src/components/organisms/index.ts` | Modify |
+
+---
+
+### Phase 4: Keyboard shortcuts + polish
+
+#### File: `app/frontend/src/App.tsx` (modify)
+
+Add a `useEffect` in `AuthenticatedApp` that listens for keyboard shortcuts:
+
+```ts
+useEffect(() => {
+  const handler = (e: KeyboardEvent) => {
+    const mod = e.metaKey || e.ctrlKey;
+    if (mod && e.shiftKey && e.key === "1") { e.preventDefault(); setContentTab("diffs"); }
+    if (mod && e.shiftKey && e.key === "2") { e.preventDefault(); setContentTab("code"); }
+    if (mod && e.shiftKey && e.key === "3") { e.preventDefault(); setContentTab("browser"); }
+    if (mod && e.key === "l" && contentTab === "browser") {
+      e.preventDefault();
+      // Focus the URL input -- requires ref forwarding from ContentTabBar
+    }
+  };
+  window.addEventListener("keydown", handler);
+  return () => window.removeEventListener("keydown", handler);
+}, [contentTab]);
+```
+
+#### Polish items
+
+- Add `aria-label` attributes to the tab bar for accessibility
+- Add a subtle transition when switching tabs (opacity fade, 100ms)
+- Persist `browserUrl` across tab switches (already handled by state living in AuthenticatedApp)
+- Iframe mount/persist is handled in Phase 2 via `hasActivatedBrowser` + `display: none` (not deferred to Phase 4)
+
+#### File: `app/frontend/src/components/molecules/ContentTabBar/ContentTabBar.tsx` (modify)
+
+Add `urlInputRef` forwarding for Cmd+L focus support.
+
+#### Files summary
+
+| File | Action |
+|------|--------|
+| `src/App.tsx` | Modify (keyboard shortcuts) |
+| `src/components/molecules/ContentTabBar/ContentTabBar.tsx` | Modify (ref forwarding) |
+
+## Complete File Tree
+
+```
+app/frontend/src/
+  types/
+    content.ts                                      [create] ContentTab type
+    sidebar.ts                                      [no change] SidebarMode stays as-is
+  components/
+    atoms/
+      Icon/
+        Icon.tsx                                    [modify] Add globe + code icons
+      UrlInput/
+        UrlInput.tsx                                [create] Compact URL input
+        index.ts                                    [create] Barrel export
+      index.ts                                      [modify] Export UrlInput
+    molecules/
+      ContentTabBar/
+        ContentTabBar.tsx                           [create] Tab bar for main content
+        index.ts                                    [create] Barrel export
+      index.ts                                      [modify] Export ContentTabBar
+    organisms/
+      BrowserPanel/
+        BrowserPanel.tsx                            [create] Iframe-based web viewer
+        index.ts                                    [create] Barrel export
+      index.ts                                      [modify] Export BrowserPanel
+    templates/
+      AppShell/
+        AppShell.tsx                                [modify] Insert ContentTabBar, new props
+  App.tsx                                           [modify] Add contentTab state, keyboard shortcuts
+```
+
+**Summary:** 7 new files, 6 modified files, 0 deleted files.
+
+## Future Direction: Native macOS via Tauri
+
+The iframe approach is intentionally simple and works today. When Stack Bench moves to a Tauri desktop app:
+
+1. **BrowserPanel becomes the swap point.** Replace the `<iframe>` with Tauri's `<webview>` component (backed by WKWebView on macOS). The component interface (`url`, `onNavigate`, `onLoad`, `onError`) remains identical -- the swap is internal to `BrowserPanel`.
+
+2. **WKWebView advantages.** No CORS/X-Frame-Options restrictions. Full DevTools access. Native scrolling. Cookie isolation. Better performance for heavy pages.
+
+3. **No architectural changes needed.** The tab system, URL bar, keyboard shortcuts, and state management all remain the same. Only the BrowserPanel internals change.
+
+4. **Progressive enhancement.** Detect the runtime environment (`window.__TAURI__` exists) and render the native webview when available, falling back to iframe in web mode. This lets the same codebase work in both contexts.
+
+## Testing Strategy
+
+**Visual verification (primary -- via `/verify`):**
+- Tab bar renders with three tabs, "Stack Diffs" active by default
+- Clicking tabs switches content correctly
+- Browser tab shows URL input inline when active
+- Entering a URL loads the page in the iframe
+- Iframe loading shows spinner, then content
+- Sites that block framing show error state with "Open in new tab" link
+- Keyboard shortcuts switch tabs correctly
+- Cmd+L focuses URL bar on Browser tab
+- Layout remains stable (no height jumps, no scroll resets) when switching tabs
+- Sidebar mode toggle still works independently of content tabs
+
+**Render smoke tests** (test file paths):
+- `__tests__/components/atoms/UrlInput.test.tsx` -- renders, handles Enter key submission
+- `__tests__/components/molecules/ContentTabBar.test.tsx` -- renders three tabs, shows URL input on browser tab, fires onTabChange
+- `__tests__/components/organisms/BrowserPanel.test.tsx` -- renders with valid URL, shows error/hint state
+
+**Integration scenarios:**
+- [ ] Load app, verify default is Diffs tab with diff content
+- [ ] Switch to Code tab, verify FileContent renders for selected file
+- [ ] Switch to Browser tab, verify URL input appears and iframe renders
+- [ ] Navigate to a URL, switch to Diffs tab, switch back -- page is still loaded (not reloaded)
+- [ ] Cmd+1/2/3 switches tabs correctly
+- [ ] Sidebar Diffs/Files toggle does not affect content tab
+- [ ] Content tab does not affect sidebar tree display
+
+## Open Questions
+
+1. **Should clicking a file in the sidebar auto-switch to the Code tab?** Two options: (a) always switch to Code tab when a file is clicked in the sidebar, or (b) only switch when already on the Code tab, and on other tabs just update `selectedPath` silently. Option (b) is less disruptive but may confuse users who expect to see the file they clicked. Recommendation: option (a) with a brief "viewing file" toast or visual cue.
+
+2. **Should the Browser tab persist its URL in the URL bar / localStorage?** Currently planned as ephemeral state in `AuthenticatedApp`. For cross-session persistence, we could save the last URL to localStorage keyed by stack ID.
+
+3. ~~**Should the PRHeader toolbar (expand/collapse all, comment mode) only show on the Diffs tab?**~~ **Resolved: Yes.** The PRHeader toolbar is diff-specific and must only render when `contentTab === "diffs"`. This is handled in Phase 2 (step 7).
+
+4. **Should we pre-populate the browser URL from the PR's deployment URL?** If the backend exposes a deployment/preview URL for the active branch's PR, the Browser tab could auto-navigate there. This is a natural follow-up but out of scope for this spec.
+
+5. **Content Security Policy.** The app itself may need a CSP `frame-src` directive to allow the iframe to load external URLs. This depends on how the frontend is served (Vite dev server vs. production Nginx). Vite dev server is permissive by default. Production Nginx may need a header update.

--- a/.claude/specs/2026-04-09-agentic-tui-standalone.md
+++ b/.claude/specs/2026-04-09-agentic-tui-standalone.md
@@ -1,0 +1,610 @@
+---
+title: agentic-tui — Standalone Package from PR #198
+date: 2026-04-09
+status: draft
+branch: null
+depends_on: [2026-04-08-agentic-tui-package.md, 2026-03-22-message-parts.md]
+adrs: []
+---
+
+# agentic-tui — Standalone Package from PR #198
+
+## Goal
+
+Build a production-ready, language-agnostic terminal chat UI for any AI agent
+backend. Start from PR #198's code (the visual source of truth) and add
+main's infrastructure (public API, JSON-RPC stdio, contract tests, examples)
+around it — never touching the rendering pipeline.
+
+## Why Start from PR #198, Not Main
+
+PR #196's extraction onto main simplified the rendering to get it working.
+Main is missing spinner presets, dual spinners, graduated escalation,
+structured diff parsing, syntax-highlighted diffs, theme auto-detect, and
+demo infrastructure. Porting those visual details forward proved lossy last
+time. PR #198 has the exact UX we want — starting from it means fidelity by
+definition.
+
+Main's additions over PR #198 are **structural, not visual**:
+- Public API wrapper (~200 lines, zero rendering interaction)
+- JSON-RPC stdio client (~570 lines, self-contained transport)
+- EndpointConfig for custom API paths (~40 lines)
+- Contract tests (~450 lines, standalone package)
+- Examples (~150 lines across 6 dirs)
+- ExecService refactor (minor rename from LocalService)
+- Type duplication + adapter boilerplate (to be eliminated, not ported)
+
+These are additive layers that wrap around rendering code without modifying
+it. Porting them into PR #198's codebase is mechanical and testable.
+
+## Current State
+
+### PR #198 branch (`dugshub/message-parts/2-part-aware-chat`)
+
+The visual truth. 14 commits of polished TUI at `app/cli/internal/*`:
+
+**Rendering pipeline (preserve exactly)**:
+- Part-aware `Message{Role, Parts []MessagePart}` model
+- Per-part dispatch: text → markdown, thinking → summary + spinner, tool_call → display-type, error → error block
+- Blank-line spacing between parts of different types
+- `indentBody` removed — tool bodies flush with header
+
+**Components (preserve exactly)**:
+- `DiffBlock` with structured `[]DiffHunk`, `ParseUnifiedDiff`, chroma syntax hl on added lines, muted blue/red palette, line numbers in marker color
+- `CodeBlock` with `│` gutter aligned to DiffBlock, filename header, chroma auto-detect
+- `ToolCallBlock` with state icons, display-type body dispatch
+- Custom goldmark renderer: hanging indent lists, table routing, code block highlighting
+- All atoms: badge, codeblock, highlight, icon, inlinecode, separator, spinner, table, textblock
+
+**Spinners (preserve exactly)**:
+- 14 frame presets (Dense, Sparse, Pulse, Heartbeat, Star, etc.)
+- Dual spinners: `toolSpinner` (SparseCenter) + `thinkingSpinner` (Star)
+- Graduated escalation: SparseCenter (< 5s) → Pulse (5-15s) → Heartbeat (> 15s)
+- StatusBar heartbeat colored by health state
+
+**Theme (preserve exactly)**:
+- Dark + light themes with design tokens
+- Auto-detect via `lipgloss.HasDarkBackground` (OSC 11)
+- `--theme` flag + env var override
+
+**Demo (preserve exactly)**:
+- `DemoClient` with structured `DemoPart` format
+- 4-exchange fixture: Q&A, multi-tool recovery, long run, tool rejection
+- `--demo`, `--demo-script`, `--demo-gallery`, `--demo-spinners` modes
+
+**Streaming**:
+- `StreamChunk` with structured tool fields
+- `ChunkFromSSE` SSE parser for the event vocabulary
+- `HTTPClient` and `StubClient` implementations
+
+### Main branch additions (port into PR #198)
+
+**Public API layer** (`packages/agent-tui/*.go`):
+- `tui.Client` interface (5 methods): `ListAgents`, `CreateConversation`, `SendMessage`, `ListConversations`, `GetConversation`
+- `tui.Config` struct: `AppName`, `AssistantLabel`, `BackendURL`, `BackendService`, `BackendStdio`, `EnvOverride`, `Theme`, `Commands`, `Endpoints`
+- `tui.App` with `New(Config)` + `Run()` — resolves backend, builds registry, starts Bubble Tea
+- `tui.EndpointConfig` for customizable API paths
+- `tui.CommandDef` for consumer-registered slash commands
+- `tui.NewHTTPClient()`, `tui.NewStdioClient()`, `tui.NewStubClient()` factories
+
+**JSON-RPC stdio client** (`packages/agent-tui/internal/stdioclient/`):
+- `client.go` (~424 lines): spawns subprocess, stdin/stdout pipes, `readLoop` goroutine
+- `jsonrpc.go` (~144 lines): JSON-RPC 2.0 wire types (Request, Response, Notification)
+- Methods: `listAgents`, `createConversation`, `sendMessage` (streaming via `stream.event` notifications), `listConversations`, `getConversation`
+- Graceful shutdown: SIGTERM → 5s grace → SIGKILL
+- Pending request tracking with `map[id]chan *Response`
+
+**HTTP client enhancements** (`packages/agent-tui/internal/httpclient/`):
+- `EndpointConfig` for overriding default API paths
+- Backward-compatible event name aliases (`message.delta` / `agent.message.chunk`)
+- Graceful `ListAgents` fallback: tries `[]AgentSummary`, falls back to `[]string`
+
+**Service lifecycle** (`packages/agent-tui/internal/service/`):
+- `ExecService` (renamed from `LocalService`): spawn + health-check any backend process
+- `ServiceManager`: multi-service orchestration, `StartAll`/`StopAll`/`HealthSummary`
+- `ServiceHealthTick` → Bubble Tea command for periodic health polling
+
+**Contract tests** (`packages/agent-tui/contracttest/`):
+- `ValidateBackend()` — validates HTTP/SSE backend contract
+- `ValidateStdioBackend()` — validates JSON-RPC backend contract
+- Both check: listAgents, createConversation, sendMessage streaming
+
+**Examples** (`packages/agent-tui/_examples/`):
+- `minimal/` — 24-line HTTP integration
+- `stdio-python/` — JSON-RPC subprocess (Python backend)
+- `stdio-typescript/` — JSON-RPC subprocess (TypeScript backend)
+- `custom-commands/` — adding slash commands
+- `custom-theme/` — custom theme
+- `demo/` and `gallery/` — demo modes
+
+## Architecture (Target)
+
+```
+github.com/ORG/agentic-tui/
+├── go.mod                        # standalone module
+├── tui.go                        # App, New(), Run() — public entry point
+├── client.go                     # Client interface + factories
+├── config.go                     # Config, EndpointConfig, CommandDef
+├── types.go                      # StreamChunk, AgentSummary, etc. (SINGLE source)
+├── service.go                    # ServiceNode alias
+├── stdio.go                      # StdioConfig
+├── demo.go                       # RunGallery, RunDemo (public)
+├── PROTOCOL.md                   # Universal backend contract
+├── LICENSE                       # MIT
+│
+├── internal/
+│   ├── app/                      # Top-level Bubble Tea model
+│   │   ├── model.go              # Phases: agent-select → chat
+│   │   ├── demo.go               # Demo runner
+│   │   ├── gallery.go            # Component showcase
+│   │   └── spinners.go           # Spinner gallery
+│   │
+│   ├── chat/                     # Chat engine (FROM PR #198)
+│   │   ├── model.go              # Part-aware messages, dual spinners, streaming
+│   │   ├── view.go               # Per-part rendering, graduation, display-type dispatch
+│   │   └── input.go              # Keystroke handling
+│   │
+│   ├── sse/                      # SSE parsing + event types
+│   │   ├── parse.go              # ParseSSE, ChunkFromSSE
+│   │   └── events.go             # Event constants, type aliases to root types
+│   │
+│   ├── httpclient/               # HTTP/SSE transport (FROM MAIN)
+│   │   ├── client.go             # HTTPClient with EndpointConfig
+│   │   └── stub.go               # StubClient
+│   │
+│   ├── stdioclient/              # JSON-RPC transport (FROM MAIN — new)
+│   │   ├── client.go             # StdioClient
+│   │   └── jsonrpc.go            # Wire types
+│   │
+│   ├── service/                  # Process lifecycle
+│   │   ├── node.go               # ServiceNode interface
+│   │   ├── local.go              # ExecService
+│   │   └── manager.go            # ServiceManager
+│   │
+│   ├── command/                  # Slash command system
+│   │   ├── registry.go           # Registry with fuzzy matching
+│   │   ├── commands.go           # Built-in: /help, /clear, /agents, /quit
+│   │   └── parse.go              # Slash command parser
+│   │
+│   └── ui/                       # Component library (FROM PR #198)
+│       ├── markdown.go           # Streaming markdown renderer
+│       ├── goldmark.go           # Custom goldmark → terminal
+│       ├── theme/                # Tokens, dark/light, auto-detect, registry
+│       ├── autocomplete/         # Slash command autocomplete
+│       └── components/
+│           ├── atoms/            # badge, codeblock, highlight, icon, spinner, etc.
+│           └── molecules/        # diffblock, diffparser, toolcallblock, etc.
+│
+├── contracttest/                 # Backend validation (FROM MAIN)
+│   ├── validate.go
+│   └── validate_stdio.go
+│
+├── _examples/                    # Reference integrations (FROM MAIN)
+│   ├── minimal/
+│   ├── stdio-python/
+│   ├── stdio-typescript/
+│   ├── custom-commands/
+│   └── custom-theme/
+│
+└── demo/                         # Demo fixtures (FROM PR #198)
+    └── fixtures/
+        ├── demo.json
+        └── demo-parts.json
+```
+
+### How rendering stays untouched
+
+The rendering pipeline lives entirely within `internal/chat/` and
+`internal/ui/`. The additions from main live in separate packages that don't
+import from these:
+
+```
+Rendering (PR #198, frozen):     Infrastructure (main, added):
+  internal/chat/view.go            tui.go, client.go, config.go
+  internal/chat/model.go           internal/httpclient/
+  internal/ui/components/          internal/stdioclient/   ← NEW
+  internal/ui/theme/               internal/service/
+  internal/ui/markdown.go          contracttest/
+  internal/ui/goldmark.go          _examples/
+```
+
+The only connection point is the `Client` interface and `StreamChunk` type —
+both are data contracts, not rendering code.
+
+## Protocol Specification
+
+### SSE Event Vocabulary (HTTP transport)
+
+| Event | Legacy Aliases | Data | Purpose |
+|-------|---------------|------|---------|
+| `message.delta` | `agent.message.chunk` | `{"delta": "..."}` | Streaming text |
+| `message.complete` | `agent.message.complete` | `{"content": "...", "input_tokens": N, "output_tokens": N}` | Message done |
+| `thinking` | `agent.reasoning` | `{"content": "..."}` | Reasoning/thinking |
+| `tool.start` | `agent.tool.start`, `tool_start` | `{"tool_call_id", "tool_name", "display_type", "arguments"}` | Tool begins |
+| `tool.end` | `agent.tool.end`, `tool_end` | `{"tool_call_id", "result", "error", "duration_ms", "display_type"}` | Tool ends |
+| `tool.rejected` | `agent.tool.rejected` | `{"tool_name", "reason"}` | Safety gate |
+| `error` | `agent.error` | `{"error_type", "message"}` | Fatal error |
+| `done` | — | `{}` | Stream complete |
+
+**Display types**: `generic` (default), `diff`, `code`, `bash`
+
+### JSON-RPC Methods (Stdio transport)
+
+| Method | Params | Result | Required |
+|--------|--------|--------|----------|
+| `listAgents` | `{}` | `[{id, name, role, model}]` | Yes |
+| `createConversation` | `{agent_id}` | `{id}` | Yes |
+| `sendMessage` | `{conversation_id, content}` | Streams via `stream.event` notifications | Yes |
+| `listConversations` | `{agent_name}` | `[{id, agent_id, state, ...}]` | No |
+| `getConversation` | `{id}` | `{id, messages, ...}` | No |
+
+### HTTP Endpoints (configurable via EndpointConfig)
+
+| Method | Default Path | Purpose |
+|--------|-------------|---------|
+| GET | `/agents` | List agents |
+| POST | `/conversations` | Create conversation |
+| POST | `/conversations/{id}/send` | Send message (SSE) |
+| GET | `/conversations` | List conversations (optional) |
+| GET | `/conversations/{id}` | Get conversation (optional) |
+| GET | `/health` | Health check |
+
+## Source Access (for ultra-plan)
+
+All source code lives in this repo across two branches. No external repos
+needed.
+
+**PR #198 files** (visual truth — rendering, components, spinners, demo):
+```
+git show origin/dugshub/message-parts/2-part-aware-chat:<path>
+```
+Example: `git show origin/dugshub/message-parts/2-part-aware-chat:app/cli/internal/chat/view.go`
+
+80 files under `app/cli/` on this branch.
+
+**Main files** (infrastructure — public API, stdio, contract tests):
+```
+Direct reads from packages/agent-tui/
+```
+68 Go files under `packages/agent-tui/`.
+
+**Work directory**: Build the standalone package at `packages/agentic-tui/`
+within this repo. Repo extraction to a separate GitHub repo is a manual
+final step outside the plan.
+
+### go.mod dependencies (merged from both branches)
+
+PR #198 has the superset of direct deps:
+```
+charm.land/bubbles/v2 v2.0.0
+charm.land/bubbletea/v2 v2.0.2
+charm.land/lipgloss/v2 v2.0.2
+github.com/alecthomas/chroma/v2 v2.23.1
+github.com/yuin/goldmark v1.7.17
+gopkg.in/yaml.v3 v3.0.1
+```
+Main's agent-tui only has `bubbletea` + `lipgloss` as direct deps (the
+others are imported transitively). The new module needs all six as direct.
+
+### SSE parser differences (Phase 5 merge guide)
+
+Main added these backward-compatible event name aliases that PR #198 lacks:
+- `message.delta` → ChunkText
+- `message.complete` → ChunkText (done)
+- `tool.start` → ChunkToolStart
+- `tool.end` → ChunkToolEnd
+
+PR #198 has richer payload parsing that main dropped:
+- `SSEToolStartData.Arguments` (map[string]any) — main only has `Input` (string)
+- `SSEToolEndData.Result` (any) — main only has `Output` (string)
+- Fallback logic: `Result` if `Output` is empty, `Input` as name fallback
+
+**Merge strategy**: Take PR #198's parser as the base (richer payloads),
+add main's four new event name aliases to the switch statement. ~10 lines.
+
+### App model wiring differences (Phase 3 reconciliation)
+
+**PR #198 constructor**: `app.New(client api.Client, mgr *service.ServiceManager) Model`
+- Creates registry internally: `command.DefaultRegistry()`
+- Has demo fields: `demo bool`, `demoRunner *DemoRunner`, `gallery bool`
+- Has `statusSpinner` for health heartbeat
+- Chat init: `chat.New(client, agentName, registry)`
+- Chat height: `m.height - 5` (accounts for status bar + header)
+
+**Main constructor**: `app.New(client sse.Client, mgr *service.ServiceManager, reg *command.Registry, cfg Config) Model`
+- Registry passed in from caller (enables consumer-registered commands)
+- Config has `AppName`, `AssistantLabel`
+- No demo/gallery fields (handled elsewhere)
+- Chat init: `chat.New(client, agentName, registry, cfg.AssistantLabel)`
+- Chat height: `m.height - 2`
+
+**Reconciliation**: Take PR #198's model (has demo/gallery/spinners), adopt
+main's signature pattern (pass registry + config in). Add `Config` struct.
+Keep PR #198's height calculation (it accounts for the richer chrome).
+
+## Implementation Phases
+
+| Phase | What | Depends On |
+|-------|------|------------|
+| 1 | Restructure PR #198 code into standalone package layout | -- |
+| 2 | Unify types into single `internal/types` package | 1 |
+| 3 | Port public API layer from main (Client, Config, App) | 2 |
+| 4 | Port JSON-RPC stdio client from main | 2 |
+| 5 | Port HTTP client enhancements from main (EndpointConfig, aliases) | 2 |
+| 6 | Port service lifecycle from main (ExecService, ServiceManager) | 2 |
+| 7 | Port contract tests and examples from main | 4, 5 |
+| 8 | Write PROTOCOL.md | -- |
+| 9 | CI, release workflow, README | 8 |
+| 10 | Integration test: wire Stack Bench against new package | 9 |
+| 11 | Tag v0.1.0, close PR #198, move #199/#200 | 10 |
+
+## Phase Details
+
+### Phase 1: Restructure PR #198 into standalone package layout
+
+Take PR #198's `app/cli/` code and reorganize into the target layout. This
+is a **pure file-move + import-path rewrite** — no logic changes.
+
+**Source → Target mapping**:
+```
+app/cli/internal/api/client.go    → internal/httpclient/client.go
+app/cli/internal/api/types.go     → types.go (root package)
+app/cli/internal/api/sse.go       → internal/sse/parse.go
+app/cli/internal/app/model.go     → internal/app/model.go
+app/cli/internal/app/demo.go      → internal/app/demo.go
+app/cli/internal/app/gallery.go   → internal/app/gallery.go
+app/cli/internal/app/spinners.go  → internal/app/spinners.go
+app/cli/internal/chat/model.go    → internal/chat/model.go
+app/cli/internal/chat/view.go     → internal/chat/view.go
+app/cli/internal/command/         → internal/command/
+app/cli/internal/service/         → internal/service/
+app/cli/internal/ui/              → internal/ui/
+app/cli/fixtures/                 → demo/fixtures/
+app/cli/main.go                   → (becomes example, not part of library)
+```
+
+**Import path rewrite**:
+```
+github.com/dugshub/stack-bench/app/cli/internal/api
+  → github.com/ORG/agentic-tui/internal/httpclient  (client parts)
+  → github.com/ORG/agentic-tui/internal/sse         (SSE parts)
+
+github.com/dugshub/stack-bench/app/cli/internal/*
+  → github.com/ORG/agentic-tui/internal/*
+```
+
+**New go.mod**:
+```
+module github.com/ORG/agentic-tui
+
+go 1.23
+
+require (
+    charm.land/bubbles/v2 v2.0.0
+    charm.land/bubbletea/v2 v2.0.2
+    charm.land/lipgloss/v2 v2.0.2
+    github.com/alecthomas/chroma/v2 v2.x.x
+    github.com/yuin/goldmark v1.7.17
+)
+```
+
+**Verification**: `go build ./...` and `go test ./...` must pass after
+restructure. The demo mode should render identically.
+
+### Phase 2: Unify types
+
+PR #198 has types scattered across `api/types.go` and `api/sse.go`. Main
+duplicated them between `tui` root and `internal/sse`. We fix this now.
+
+**Create `internal/types/` as single source**:
+```go
+// internal/types/types.go
+package types
+
+type AgentSummary struct { ... }
+type Conversation struct { ... }
+type ConversationDetail struct { ... }
+type ConversationMessage struct { ... }
+type MessagePart struct { ... }
+type ChunkType string
+type StreamChunk struct { ... }
+```
+
+**Root package re-exports via aliases**:
+```go
+// types.go (root)
+package tui
+import "github.com/ORG/agentic-tui/internal/types"
+type StreamChunk = types.StreamChunk
+type AgentSummary = types.AgentSummary
+// etc.
+```
+
+**All internal packages import `internal/types`** — no cycles, no adapters,
+no conversion boilerplate.
+
+### Phase 3: Port public API layer from main
+
+Take main's `packages/agent-tui/{tui.go,client.go,config.go,command.go,
+service.go,stdio.go,theme.go}` and adapt to the new type-unified layout.
+
+**Key simplification**: No `publicClientAdapter` or `internalClientAdapter`.
+Transport implementations return `types.StreamChunk` directly. The `Client`
+interface uses `types.StreamChunk`. Zero conversion.
+
+**Files to create**:
+- `tui.go` — `App` struct, `New()`, `Run()`, `RunGallery()`
+- `client.go` — `Client` interface, `NewHTTPClient()`, `NewStdioClient()`, `NewStubClient()`
+- `config.go` — `Config`, `EndpointConfig`, `CommandDef`
+- `service.go` — `ServiceNode` type alias
+- `stdio.go` — `StdioConfig`
+- `theme.go` — `Theme` type alias
+
+**Adaptation needed**: Main's `App.resolveBackend()` and `App.Run()` work
+as-is once the type adapters are removed. Main's `buildRegistry()` for
+consumer commands works as-is.
+
+### Phase 4: Port JSON-RPC stdio client from main
+
+Copy `packages/agent-tui/internal/stdioclient/` directly. This is a
+self-contained package that depends only on `internal/types` (after
+phase 2 unification).
+
+**Files**:
+- `internal/stdioclient/client.go` (~424 lines)
+- `internal/stdioclient/jsonrpc.go` (~144 lines)
+
+**Changes**: Replace `internal/sse` type imports with `internal/types`.
+The `convertStreamEvent()` function maps JSON-RPC stream notifications to
+`types.StreamChunk` — same logic, just importing from a different package.
+
+**Test**: Port `client_test.go` from main.
+
+### Phase 5: Port HTTP client enhancements from main
+
+PR #198's `HTTPClient` is functional but doesn't have main's improvements:
+
+**EndpointConfig**: Configurable API paths instead of hardcoded strings.
+Take from `packages/agent-tui/internal/httpclient/client.go`.
+
+**Event name aliases**: Main added backward-compatible aliases
+(`message.delta` / `agent.message.chunk`) in the SSE parser. Merge these
+into the `ChunkFromSSE` function.
+
+**ListAgents fallback**: Try `[]AgentSummary`, fall back to `[]string`.
+This handles backends that return simple name arrays.
+
+**StubClient**: Enhanced version from main with proper `StubClient` struct.
+
+### Phase 6: Port service lifecycle from main
+
+Copy `packages/agent-tui/internal/service/` — it's almost identical to
+PR #198's `service/` but with `ExecService` (renamed from `LocalService`)
+and a few polish fixes.
+
+- `node.go` — `ServiceNode` interface (same)
+- `local.go` — `ExecService` (renamed, same logic)
+- `manager.go` — `ServiceManager` (same)
+
+### Phase 7: Port contract tests and examples from main
+
+**Contract tests** — copy `packages/agent-tui/contracttest/`:
+- `validate.go` — HTTP backend contract validation
+- `validate_stdio.go` — JSON-RPC backend contract validation
+- Update imports to new module path
+
+**Examples** — copy `packages/agent-tui/_examples/`:
+- `minimal/main.go` — 24-line HTTP example
+- `stdio-python/` — Python JSON-RPC backend
+- `stdio-typescript/` — TypeScript JSON-RPC backend
+- `custom-commands/main.go` — registering custom slash commands
+- `custom-theme/main.go` — custom theme
+- Update imports to new module path
+
+### Phase 8: Write PROTOCOL.md
+
+Stable reference for backend implementors in any language.
+
+Contents:
+1. SSE event vocabulary with full JSON schemas
+2. JSON-RPC method definitions (params, results, error codes)
+3. HTTP endpoint conventions (paths, headers, SSE wire format)
+4. Display type registry and rendering behavior
+5. Streaming lifecycle (connect → stream → done/error)
+6. Backward compatibility guarantees
+7. "Implementing a backend in 30 minutes" quick-start
+
+### Phase 9: CI, release workflow, README
+
+**GitHub Actions** (`.github/workflows/`):
+- `ci.yml`: `go test`, `go vet`, `golangci-lint` on push/PR
+- `release.yml`: on tag push, build static binaries for 5 platforms, upload to GH Releases
+
+**README.md**: one-paragraph description, quick-start (3 integration patterns), protocol overview, screenshots/recordings, links to examples.
+
+**LICENSE**: MIT (matches Bubble Tea, lipgloss, goldmark, chroma).
+
+### Phase 10: Stack Bench integration
+
+- Update `app/cli/go.mod`: replace local `packages/agent-tui` with published module
+- Verify `app/cli/main.go` works (may need minor Config field updates)
+- Delete `packages/agent-tui/` from stack-bench
+- Run full demo to confirm visual parity
+
+### Phase 11: Ship v0.1.0
+
+- Tag `v0.1.0`
+- Close PR #198 with migration note
+- Move #199, #200 to new repo
+- Archive this spec
+
+## Risk Analysis
+
+**Low risk** (file moves + import rewrites):
+- Phase 1 (restructure) — mechanical, verified by `go build`
+- Phase 2 (unify types) — well-understood Go pattern
+- Phases 4-7 (port from main) — copying self-contained packages
+
+**Medium risk**:
+- Phase 3 (public API) — adapting main's wrapper to PR #198's internals.
+  Main's `app.Config` vs PR #198's `app.New()` signature may differ slightly.
+  Mitigation: compare function signatures before porting.
+- Phase 5 (HTTP enhancements) — merging main's SSE parser improvements into
+  PR #198's parser. Same event types, different code. Mitigation: diff the
+  two parsers, take the superset.
+
+**Zero risk to visual fidelity**: Phases 1-7 never modify files in
+`internal/chat/view.go`, `internal/ui/components/`, `internal/ui/theme/`,
+or `internal/ui/markdown.go`. These are the rendering pipeline and they
+stay frozen.
+
+## Open Questions
+
+1. **Repo name + org**: `dugshub/agentic-tui`? Decides Go module path.
+2. **Module path**: Use vanity import path or GitHub directly?
+3. **Bubble Tea v2 pin**: Document exact version, it's pre-1.0.
+4. **Keep legacy event aliases forever?** Yes for v0.x, revisit for v1.0.
+
+## What's NOT in v0.1.0
+
+- Python SDK wrapper / wheel bundling
+- Homebrew/apt distribution
+- Expandable/interactive parts (#199)
+- Word-level diff highlights (#200)
+- Tool approval protocol
+- Custom display type plugins
+- Multi-TUI theme isolation
+
+## Reference: Source Files
+
+### From PR #198 (the visual truth — keep as-is)
+
+```
+app/cli/internal/chat/model.go     — Part-aware messages, dual spinners, streaming
+app/cli/internal/chat/view.go      — Per-part rendering, graduation, display-type
+app/cli/internal/ui/               — All components, theme, markdown
+app/cli/internal/app/              — App model, demo, gallery, spinners
+app/cli/internal/command/          — Slash command registry
+app/cli/internal/api/sse.go        — SSE parser
+app/cli/internal/api/types.go      — StreamChunk, DTOs
+app/cli/internal/api/client.go     — HTTPClient, StubClient
+app/cli/internal/service/          — LocalService, ServiceManager
+app/cli/fixtures/                  — Demo fixtures
+```
+
+### From main (infrastructure to add)
+
+```
+packages/agent-tui/tui.go           — App, New(), Run()
+packages/agent-tui/client.go        — Client interface, factories, adapters (simplify)
+packages/agent-tui/config.go        — Config, EndpointConfig
+packages/agent-tui/types.go         — Public type re-exports (merge with PR #198 types)
+packages/agent-tui/command.go       — CommandDef
+packages/agent-tui/service.go       — ServiceNode alias
+packages/agent-tui/stdio.go         — StdioConfig
+packages/agent-tui/theme.go         — Theme alias
+packages/agent-tui/internal/stdioclient/  — JSON-RPC client (NEW, doesn't exist in PR #198)
+packages/agent-tui/internal/httpclient/   — Enhanced HTTP client (merge improvements)
+packages/agent-tui/contracttest/          — Backend validation (NEW)
+packages/agent-tui/_examples/             — Reference integrations (NEW)
+```


### PR DESCRIPTION
## Summary
- Comprehensive spec for extracting the TUI into a standalone, language-agnostic Go package
- Starts from PR #198 (visual source of truth) and ports main's infrastructure around it
- Includes protocol specification, 11 implementation phases, SSE parser merge guide, and app model reconciliation details
- Also includes the embedded browser tabs spec from a prior session

## Context
Prep for ultra-plan iteration on the agentic-tui standalone package. All source code references are self-contained within this repo (PR #198 branch + main).

## Test plan
- [ ] Spec reviewed for completeness and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)