### PR TITLE
docs: EP-017 epic + issues for agentic-tui standalone package

### DIFF
--- a/.claude/specs/2026-04-09-agentic-tui-standalone.md
+++ b/.claude/specs/2026-04-09-agentic-tui-standalone.md
@@ -135,7 +135,7 @@ The visual truth. 14 commits of polished TUI at `app/cli/internal/*`:
 ## Architecture (Target)
 
 ```
-github.com/ORG/agentic-tui/
+github.com/dugshub/agentic-tui/
 ├── go.mod                        # standalone module
 ├── tui.go                        # App, New(), Run() — public entry point
 ├── client.go                     # Client interface + factories
@@ -339,19 +339,22 @@ Keep PR #198's height calculation (it accounts for the richer chrome).
 
 ## Implementation Phases
 
-| Phase | What | Depends On |
-|-------|------|------------|
-| 1 | Restructure PR #198 code into standalone package layout | -- |
-| 2 | Unify types into single `internal/types` package | 1 |
-| 3 | Port public API layer from main (Client, Config, App) | 2 |
-| 4 | Port JSON-RPC stdio client from main | 2 |
-| 5 | Port HTTP client enhancements from main (EndpointConfig, aliases) | 2 |
-| 6 | Port service lifecycle from main (ExecService, ServiceManager) | 2 |
-| 7 | Port contract tests and examples from main | 4, 5 |
-| 8 | Write PROTOCOL.md | -- |
-| 9 | CI, release workflow, README | 8 |
-| 10 | Integration test: wire Stack Bench against new package | 9 |
-| 11 | Tag v0.1.0, close PR #198, move #199/#200 | 10 |
+| Issue | What | Depends On | Parallel? |
+|-------|------|------------|-----------|
+| SB-058 | Scaffold standalone package from PR #198 | -- | No (foundation) |
+| SB-059 | Unify types into single `internal/types` package | SB-058 | No (enables rest) |
+| SB-060 | Port public API layer from main | SB-059 | Yes (with 061-063) |
+| SB-061 | Port JSON-RPC stdio client from main | SB-059 | Yes (with 060,062,063) |
+| SB-062 | Port HTTP client enhancements from main | SB-059 | Yes (with 060,061,063) |
+| SB-063 | Port service lifecycle from main | SB-059 | Yes (with 060-062) |
+| SB-064 | Contract tests, examples, PROTOCOL.md | SB-061, SB-062 | No (capstone) |
+
+```
+SB-058 (scaffold) → SB-059 (unify types) → ┬─ SB-060 (public API)      ─┐
+                                             ├─ SB-061 (stdio client)     ├─ SB-064 (tests+examples+protocol)
+                                             ├─ SB-062 (HTTP enhancements)┘
+                                             └─ SB-063 (service lifecycle)
+```
 
 ## Phase Details
 
@@ -385,16 +388,16 @@ app/cli/main.go                   → (becomes example, not part of library)
 **Import path rewrite**:
 ```
 github.com/dugshub/stack-bench/app/cli/internal/api
-  → github.com/ORG/agentic-tui/internal/httpclient  (client parts)
-  → github.com/ORG/agentic-tui/internal/sse         (SSE parts)
+  → github.com/dugshub/agentic-tui/internal/httpclient  (client parts)
+  → github.com/dugshub/agentic-tui/internal/sse         (SSE parts)
 
 github.com/dugshub/stack-bench/app/cli/internal/*
-  → github.com/ORG/agentic-tui/internal/*
+  → github.com/dugshub/agentic-tui/internal/*
 ```
 
 **New go.mod**:
 ```
-module github.com/ORG/agentic-tui
+module github.com/dugshub/agentic-tui
 
 go 1.23
 
@@ -433,7 +436,7 @@ type StreamChunk struct { ... }
 ```go
 // types.go (root)
 package tui
-import "github.com/ORG/agentic-tui/internal/types"
+import "github.com/dugshub/agentic-tui/internal/types"
 type StreamChunk = types.StreamChunk
 type AgentSummary = types.AgentSummary
 // etc.
@@ -505,7 +508,7 @@ and a few polish fixes.
 - `local.go` — `ExecService` (renamed, same logic)
 - `manager.go` — `ServiceManager` (same)
 
-### Phase 7: Port contract tests and examples from main
+### Phase 7 (SB-064): Contract tests, examples, PROTOCOL.md
 
 **Contract tests** — copy `packages/agent-tui/contracttest/`:
 - `validate.go` — HTTP backend contract validation
@@ -520,11 +523,7 @@ and a few polish fixes.
 - `custom-theme/main.go` — custom theme
 - Update imports to new module path
 
-### Phase 8: Write PROTOCOL.md
-
-Stable reference for backend implementors in any language.
-
-Contents:
+**PROTOCOL.md** — stable reference for backend implementors:
 1. SSE event vocabulary with full JSON schemas
 2. JSON-RPC method definitions (params, results, error codes)
 3. HTTP endpoint conventions (paths, headers, SSE wire format)
@@ -533,62 +532,44 @@ Contents:
 6. Backward compatibility guarantees
 7. "Implementing a backend in 30 minutes" quick-start
 
-### Phase 9: CI, release workflow, README
-
-**GitHub Actions** (`.github/workflows/`):
-- `ci.yml`: `go test`, `go vet`, `golangci-lint` on push/PR
-- `release.yml`: on tag push, build static binaries for 5 platforms, upload to GH Releases
-
-**README.md**: one-paragraph description, quick-start (3 integration patterns), protocol overview, screenshots/recordings, links to examples.
-
-**LICENSE**: MIT (matches Bubble Tea, lipgloss, goldmark, chroma).
-
-### Phase 10: Stack Bench integration
-
-- Update `app/cli/go.mod`: replace local `packages/agent-tui` with published module
-- Verify `app/cli/main.go` works (may need minor Config field updates)
-- Delete `packages/agent-tui/` from stack-bench
-- Run full demo to confirm visual parity
-
-### Phase 11: Ship v0.1.0
-
-- Tag `v0.1.0`
-- Close PR #198 with migration note
-- Move #199, #200 to new repo
-- Archive this spec
-
 ## Risk Analysis
 
 **Low risk** (file moves + import rewrites):
-- Phase 1 (restructure) — mechanical, verified by `go build`
-- Phase 2 (unify types) — well-understood Go pattern
-- Phases 4-7 (port from main) — copying self-contained packages
+- SB-058 (scaffold) — mechanical, verified by `go build`
+- SB-059 (unify types) — well-understood Go pattern
+- SB-061, SB-063 (stdio, service) — copying self-contained packages
 
 **Medium risk**:
-- Phase 3 (public API) — adapting main's wrapper to PR #198's internals.
-  Main's `app.Config` vs PR #198's `app.New()` signature may differ slightly.
-  Mitigation: compare function signatures before porting.
-- Phase 5 (HTTP enhancements) — merging main's SSE parser improvements into
-  PR #198's parser. Same event types, different code. Mitigation: diff the
-  two parsers, take the superset.
+- SB-060 (public API) — adapting main's wrapper to PR #198's internals.
+  Main's `app.Config` vs PR #198's `app.New()` signature differ. Reconciliation
+  documented in the SSE parser and app model sections above.
+- SB-062 (HTTP enhancements) — merging main's SSE parser improvements into
+  PR #198's parser. Strategy: PR #198 base + main's 4 aliases (~10 lines).
 
-**Zero risk to visual fidelity**: Phases 1-7 never modify rendering logic in
+**Zero risk to visual fidelity**: No issue modifies rendering logic in
 `internal/chat/view.go`, `internal/ui/components/`, `internal/ui/theme/`,
 or `internal/ui/markdown.go`. These are the rendering pipeline and they
 stay frozen. The ONLY acceptable changes to these files are import path
 rewrites (e.g., `github.com/dugshub/stack-bench/app/cli/internal/ui` →
-`github.com/ORG/agentic-tui/internal/ui`). Any other change to rendering
+`github.com/dugshub/agentic-tui/internal/ui`). Any other change to rendering
 files is a bug in the plan execution, not an improvement.
 
-## Open Questions
+## Resolved Decisions
 
-1. **Repo name + org**: `dugshub/agentic-tui`? Decides Go module path.
-2. **Module path**: Use vanity import path or GitHub directly?
-3. **Bubble Tea v2 pin**: Document exact version, it's pre-1.0.
-4. **Keep legacy event aliases forever?** Yes for v0.x, revisit for v1.0.
+1. **Module path**: `github.com/dugshub/agentic-tui` — matches brand, can transfer org later.
+2. **Bubble Tea v2**: Pin `charm.land/bubbletea/v2 v2.0.2` (pre-1.0, document in go.mod).
+3. **Legacy event aliases**: Keep in v0.x for backward compat, revisit for v1.0.
+4. **BranchConversation**: Dropped from Client interface (stack-bench-specific).
+5. **Theme system**: Keep PR #198's YAML-loaded themes (`themes/dark.yml`, `themes/light.yml`, `embed.go`).
+6. **Chat model**: Keep PR #198's `PartType string` constants and struct-based `ToolCallPart` (richer than main's iota pattern).
+7. **SSE parser**: PR #198 base + main's 4 canonical aliases (~10 lines added).
+8. **Stdio protocol**: JSON-RPC 2.0 (already shipped on main, more capable than spec's simpler SSE-over-stdin).
+9. **Work directory**: Build at `packages/agentic-tui/` in this repo. Repo extraction is a post-epic ship task.
 
-## What's NOT in v0.1.0
+## What's NOT in This Epic
 
+- CI/CD pipelines, GitHub Release workflow, README.md (post-epic ship tasks)
+- Stack Bench integration (post-epic: update `app/cli/go.mod`, delete `packages/agent-tui/`)
 - Python SDK wrapper / wheel bundling
 - Homebrew/apt distribution
 - Expandable/interactive parts (#199)
@@ -596,6 +577,12 @@ files is a bug in the plan execution, not an improvement.
 - Tool approval protocol
 - Custom display type plugins
 - Multi-TUI theme isolation
+
+## Epic & Issues
+
+This spec is implemented via **EP-017** with 7 issues (SB-058 through SB-064).
+See `docs/epics/ep-017-agentic-tui-standalone.md` for the full issue table
+and dependency graph.
 
 ## Reference: Source Files
 

--- a/docs/epics/ep-017-agentic-tui-standalone.md
+++ b/docs/epics/ep-017-agentic-tui-standalone.md
@@ -1,0 +1,68 @@
+---
+id: EP-017
+title: agentic-tui standalone package
+status: planning
+created: 2026-04-09
+target:
+---
+
+# agentic-tui Standalone Package
+
+## Objective
+
+Extract the TUI from PR #198 into a standalone, language-agnostic Go package
+at `packages/agentic-tui/` (module `github.com/dugshub/agentic-tui`). The
+package must preserve PR #198's exact visual output while adding main's
+infrastructure (public API, JSON-RPC stdio, contract tests, examples). Any
+agent framework in any language can drive it via HTTP/SSE or JSON-RPC.
+
+## Issues
+
+| ID | Title | Status | Branch | Depends On |
+|----|-------|--------|--------|------------|
+| SB-058 | Scaffold standalone package from PR #198 | draft | | -- |
+| SB-059 | Unify types into single source | draft | | SB-058 |
+| SB-060 | Port public API layer from main | draft | | SB-059 |
+| SB-061 | Port JSON-RPC stdio client from main | draft | | SB-059 |
+| SB-062 | Port HTTP client enhancements from main | draft | | SB-059 |
+| SB-063 | Port service lifecycle from main | draft | | SB-059 |
+| SB-064 | Contract tests, examples, PROTOCOL.md | draft | | SB-061, SB-062 |
+
+## Dependency Graph
+
+```
+SB-058 (scaffold)
+  └── SB-059 (unify types)
+        ├── SB-060 (public API)
+        ├── SB-061 (stdio client)    ──┐
+        ├── SB-062 (HTTP enhancements) ├── SB-064 (tests + examples + protocol)
+        └── SB-063 (service lifecycle) │
+                                       ┘
+```
+
+After SB-059, issues SB-060 through SB-063 can run in parallel.
+SB-064 depends on SB-061 + SB-062 (contract tests validate both transports).
+
+## Critical Constraint
+
+PR #198 (`origin/dugshub/message-parts/2-part-aware-chat`) is the frozen
+visual truth. Rendering code (chat/view.go, ui/components/, ui/theme/,
+ui/markdown.go) must be copied verbatim from that branch — only import path
+rewrites are acceptable changes. See spec for full rationale.
+
+## Acceptance Criteria
+
+- [ ] `packages/agentic-tui/` exists as standalone Go module
+- [ ] `go build ./...` passes from `packages/agentic-tui/`
+- [ ] `go test ./...` passes from `packages/agentic-tui/`
+- [ ] Demo mode renders identically to PR #198
+- [ ] Public `tui.Client` interface works with HTTP, Stdio, Stub, and custom backends
+- [ ] PROTOCOL.md documents SSE events, JSON-RPC methods, HTTP endpoints
+- [ ] Contract tests validate both HTTP and stdio transports
+- [ ] Examples exist for minimal, stdio-python, stdio-typescript, custom-commands, custom-theme
+
+## Notes
+
+- Spec: `.claude/specs/2026-04-09-agentic-tui-standalone.md`
+- PR #198: pattern-stack/stack-bench#198
+- Repo extraction (to separate GitHub repo) and CI/release are post-epic ship tasks

--- a/docs/issues/sb-058-scaffold-from-pr198.md
+++ b/docs/issues/sb-058-scaffold-from-pr198.md
@@ -1,0 +1,90 @@
+---
+id: SB-058
+title: Scaffold standalone package from PR #198
+status: draft
+epic: EP-017
+depends_on: []
+branch:
+pr:
+stack: agentic-tui
+stack_index: 1
+created: 2026-04-09
+---
+
+# Scaffold standalone package from PR #198
+
+## Summary
+
+Copy all TUI code from PR #198's `app/cli/` into `packages/agentic-tui/`
+with restructured imports. This is a pure file-move + import-path rewrite
+with zero logic changes. The rendering code is frozen — only import paths
+change.
+
+## Scope
+
+What's in:
+- Copy `app/cli/internal/` files from `origin/dugshub/message-parts/2-part-aware-chat`
+- Copy `app/cli/fixtures/` → `packages/agentic-tui/demo/fixtures/`
+- Copy `app/cli/themes/` → `packages/agentic-tui/themes/` (YAML-loaded themes)
+- Create `packages/agentic-tui/go.mod` with module `github.com/dugshub/agentic-tui`
+- Rewrite all imports from `github.com/dugshub/stack-bench/app/cli/internal/` → `github.com/dugshub/agentic-tui/internal/`
+- Split `internal/api/` → `internal/httpclient/` (client code) + `internal/sse/` (parser + event types)
+- Drop `BranchConversation` from client interface (stack-bench-specific)
+
+What's out:
+- `app/cli/main.go` — this becomes an example later, not part of the library
+- Type unification (SB-059)
+- Any rendering logic changes
+
+## Implementation
+
+Source (read via `git show origin/dugshub/message-parts/2-part-aware-chat:<path>`):
+```
+app/cli/internal/api/client.go     → internal/httpclient/client.go
+app/cli/internal/api/types.go      → internal/sse/types.go (temporary, unified in SB-059)
+app/cli/internal/api/sse.go        → internal/sse/parse.go
+app/cli/internal/api/demo.go       → internal/demo/client.go
+app/cli/internal/app/model.go      → internal/app/model.go
+app/cli/internal/app/demo.go       → internal/app/demo.go
+app/cli/internal/app/gallery.go    → internal/app/gallery.go
+app/cli/internal/app/spinners.go   → internal/app/spinners.go
+app/cli/internal/chat/model.go     → internal/chat/model.go
+app/cli/internal/chat/view.go      → internal/chat/view.go
+app/cli/internal/command/          → internal/command/
+app/cli/internal/service/          → internal/service/
+app/cli/internal/ui/               → internal/ui/
+app/cli/fixtures/                  → demo/fixtures/
+app/cli/themes/                    → themes/
+```
+
+New `go.mod`:
+```
+module github.com/dugshub/agentic-tui
+
+go 1.25.0
+
+require (
+    charm.land/bubbles/v2 v2.0.0
+    charm.land/bubbletea/v2 v2.0.2
+    charm.land/lipgloss/v2 v2.0.2
+    github.com/alecthomas/chroma/v2 v2.23.1
+    github.com/yuin/goldmark v1.7.17
+    gopkg.in/yaml.v3 v3.0.1
+)
+```
+
+Copy `go.sum` from PR #198's `app/cli/go.sum` and update module paths.
+
+## Verification
+
+- [ ] `cd packages/agentic-tui && go build ./...` passes
+- [ ] `cd packages/agentic-tui && go vet ./...` passes
+- [ ] All existing tests pass: `go test ./...`
+- [ ] No files import `github.com/dugshub/stack-bench` (grep confirms zero hits)
+- [ ] `BranchConversation` does not appear in any client interface
+
+## Notes
+
+- Read PR #198 files via: `git show origin/dugshub/message-parts/2-part-aware-chat:<path>`
+- The `themes/` directory contains `dark.yml`, `light.yml`, and `embed.go` for YAML-loaded themes — this is the PR #198 theme system, preserve it exactly
+- PR #198 uses `PartType string` constants and struct-based `ToolCallPart` — keep this model

--- a/docs/issues/sb-059-unify-types.md
+++ b/docs/issues/sb-059-unify-types.md
@@ -1,0 +1,81 @@
+---
+id: SB-059
+title: Unify types into single source
+status: draft
+epic: EP-017
+depends_on: [SB-058]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 2
+created: 2026-04-09
+---
+
+# Unify types into single source
+
+## Summary
+
+Create `internal/types/` as the single source of truth for all shared types
+(`StreamChunk`, `ChunkType`, `AgentSummary`, `Conversation`, etc.) and the
+`Client` interface. All internal packages import from `internal/types/`.
+Root package re-exports via type aliases for the public API. This eliminates
+the duplicate type definitions and adapter boilerplate from the rushed
+PR #196 extraction.
+
+## Scope
+
+What's in:
+- Create `internal/types/types.go` — all DTOs (`AgentSummary`, `StreamChunk`, `ChunkType`, `Conversation`, `ConversationDetail`, `ConversationMessage`, `MessagePart`)
+- Create `internal/types/client.go` — `Client` interface (5 methods: `ListAgents`, `CreateConversation`, `SendMessage`, `ListConversations`, `GetConversation`)
+- Update `internal/httpclient/` to import `internal/types`
+- Update `internal/sse/` to import `internal/types` (keep parse logic, remove type defs)
+- Update `internal/chat/` to import `internal/types`
+- Update `internal/app/` to import `internal/types`
+- Prepare root-level `types.go` with `type StreamChunk = types.StreamChunk` aliases
+
+What's out:
+- Public API wiring (SB-060)
+- Transport implementations (SB-061, SB-062)
+
+## Implementation
+
+```
+packages/agentic-tui/
+  internal/types/
+    types.go      ← canonical: AgentSummary, StreamChunk, ChunkType, Conversation, etc.
+    client.go     ← canonical: Client interface
+```
+
+Type definitions come from PR #198's `api/types.go` (richer than main's):
+- `ChunkType` as `string` constants (not `int` iota)
+- `StreamChunk` with `Arguments map[string]any`, `Result string`, `ToolError string`, `DurationMs int`
+- `ChunkToolReject` and `ChunkIteration` types included
+
+Root re-exports:
+```go
+// packages/agentic-tui/types.go
+package tui
+import "github.com/dugshub/agentic-tui/internal/types"
+type StreamChunk = types.StreamChunk
+type ChunkType = types.ChunkType
+type AgentSummary = types.AgentSummary
+type Conversation = types.Conversation
+type ConversationDetail = types.ConversationDetail
+type Client = types.Client
+// etc.
+```
+
+## Verification
+
+- [ ] `go build ./...` passes
+- [ ] `go vet ./...` passes
+- [ ] `grep -r "type StreamChunk struct" packages/agentic-tui/` returns exactly 1 hit (in `internal/types/`)
+- [ ] `grep -r "type AgentSummary struct" packages/agentic-tui/` returns exactly 1 hit
+- [ ] No `publicClientAdapter` or `internalClientAdapter` exists
+- [ ] All tests pass: `go test ./...`
+
+## Notes
+
+- The `Client` interface must NOT include `BranchConversation` (dropped in SB-058)
+- `ListConversations` and `GetConversation` are optional — return `(nil, nil)` to skip
+- `SendMessage` returns `<-chan StreamChunk` — the channel type must be `types.StreamChunk`

--- a/docs/issues/sb-060-port-public-api.md
+++ b/docs/issues/sb-060-port-public-api.md
@@ -1,0 +1,78 @@
+---
+id: SB-060
+title: Port public API layer from main
+status: draft
+epic: EP-017
+depends_on: [SB-059]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 3
+created: 2026-04-09
+---
+
+# Port public API layer from main
+
+## Summary
+
+Add the public API surface that consumers use to configure and run the TUI.
+Adapted from main's `packages/agent-tui/{tui.go,client.go,config.go,...}` but
+simplified — no adapter boilerplate since types are now unified (SB-059).
+
+## Scope
+
+What's in:
+- `tui.go` — `App` struct, `New(Config)`, `Run()`, `RunGallery()`
+- `client.go` — `NewHTTPClient()`, `NewStdioClient()`, `NewStubClient()` factories
+- `config.go` — `Config`, `EndpointConfig`, `CommandDef`
+- `service.go` — `ServiceNode` type alias
+- `stdio.go` — `StdioConfig` struct
+- `theme.go` — `Theme` type alias
+- Reconcile `app.New()` signature: adopt main's `(client, mgr, reg, cfg)` pattern but keep PR #198's model fields (demo, gallery, statusSpinner)
+- Delete `internal_bridge.go` if it exists (no longer needed)
+
+What's out:
+- `publicClientAdapter` / `internalClientAdapter` — eliminated by type unification
+- Transport implementations (SB-061, SB-062)
+- Service lifecycle details (SB-063)
+
+## Implementation
+
+Source: `packages/agent-tui/{tui.go,client.go,config.go,command.go,service.go,stdio.go,theme.go}`
+
+Key adaptations from main:
+- `App.resolveBackend()` works as-is once adapters are removed
+- `App.buildRegistry()` for consumer commands works as-is
+- `App.Run()` — service start, signal handling, Bubble Tea program creation
+- Transport factories return `types.Client` directly (no wrapping)
+
+Reconcile `internal/app/model.go`:
+- Adopt main's constructor: `New(client types.Client, mgr *service.ServiceManager, reg *command.Registry, cfg Config) Model`
+- Add `Config` struct: `AppName string`, `AssistantLabel string`
+- Keep PR #198's model fields: `demo bool`, `demoRunner *DemoRunner`, `gallery bool`, `statusSpinner atoms.Spinner`
+- Keep PR #198's height calculation (`m.height - 5`, accounts for richer chrome)
+- Pass `cfg.AssistantLabel` to `chat.New()`
+
+```
+packages/agentic-tui/
+  tui.go          ← App, New, Run, RunGallery
+  client.go       ← NewHTTPClient, NewStdioClient, NewStubClient (thin factories)
+  config.go       ← Config, EndpointConfig, CommandDef
+  types.go        ← re-exports from internal/types (already created in SB-059)
+  service.go      ← type ServiceNode = service.ServiceNode
+  stdio.go        ← StdioConfig struct
+  theme.go        ← type Theme = theme.Theme
+```
+
+## Verification
+
+- [ ] `go build ./...` passes
+- [ ] A minimal consumer program can `tui.New(cfg)` and `app.Run()` compiles
+- [ ] `Config` supports all three backend modes: `BackendURL`, `BackendService`, `BackendStdio`
+- [ ] `Config.Commands` allows registering custom slash commands
+- [ ] No `publicClientAdapter` or `internalClientAdapter` in the codebase
+
+## Notes
+
+- Source for main's public API: `packages/agent-tui/tui.go` (166 lines), `client.go` (149 lines), `config.go` (42 lines)
+- The `OnReady` callback in main's Config is optional — include it if present, skip if not

--- a/docs/issues/sb-061-port-stdio-client.md
+++ b/docs/issues/sb-061-port-stdio-client.md
@@ -1,0 +1,70 @@
+---
+id: SB-061
+title: Port JSON-RPC stdio client from main
+status: draft
+epic: EP-017
+depends_on: [SB-059]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 4
+created: 2026-04-09
+---
+
+# Port JSON-RPC stdio client from main
+
+## Summary
+
+Copy the JSON-RPC 2.0 stdio client from main's `packages/agent-tui/internal/stdioclient/`
+into the standalone package. This is a self-contained transport that spawns a
+subprocess and communicates via JSON-RPC over stdin/stdout. It enables any
+language SDK to drive the TUI without HTTP.
+
+## Scope
+
+What's in:
+- Copy `internal/stdioclient/client.go` (~424 lines)
+- Copy `internal/stdioclient/jsonrpc.go` (~144 lines)
+- Port `internal/stdioclient/client_test.go`
+- Update imports to use `internal/types` instead of `internal/sse`
+
+What's out:
+- StdioConfig public type (SB-060)
+- Contract tests for stdio (SB-064)
+- Examples (SB-064)
+
+## Implementation
+
+Source: `packages/agent-tui/internal/stdioclient/`
+
+```
+packages/agentic-tui/internal/stdioclient/
+  client.go     ← StdioClient: spawn subprocess, stdin/stdout pipes, readLoop goroutine
+  jsonrpc.go    ← Wire types: Request, Response, Notification
+  client_test.go
+```
+
+Changes from main's version:
+- Replace `internal/sse` imports with `internal/types`
+- `convertStreamEvent()` maps JSON-RPC `stream.event` notifications to `types.StreamChunk`
+- `Client` struct implements `types.Client` interface directly (no adapter)
+
+JSON-RPC methods supported:
+- `listAgents` → `[]types.AgentSummary`
+- `createConversation` → `{id: string}`
+- `sendMessage` → streaming via `stream.event` notifications
+- `listConversations` → `[]types.Conversation` (optional, -32601 if unsupported)
+- `getConversation` → `types.ConversationDetail` (optional)
+
+## Verification
+
+- [ ] `go build ./internal/stdioclient/...` passes
+- [ ] `go test ./internal/stdioclient/...` passes
+- [ ] `StdioClient` implements `types.Client` interface (compile-time check)
+- [ ] No imports from `internal/sse` (only `internal/types`)
+
+## Notes
+
+- The stdio client handles graceful shutdown: SIGTERM → 5s grace → SIGKILL
+- Pending requests tracked in `map[id]chan *Response` with mutex
+- Stream events arrive as `stream.event` notifications (no `id` field — they're JSON-RPC notifications, not responses)

--- a/docs/issues/sb-062-port-http-enhancements.md
+++ b/docs/issues/sb-062-port-http-enhancements.md
@@ -1,0 +1,91 @@
+---
+id: SB-062
+title: Port HTTP client enhancements from main
+status: draft
+epic: EP-017
+depends_on: [SB-059]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 5
+created: 2026-04-09
+---
+
+# Port HTTP client enhancements from main
+
+## Summary
+
+Merge main's HTTP client improvements into the PR #198 base: configurable
+endpoint paths, backward-compatible SSE event name aliases, and graceful
+ListAgents fallback. The SSE parser merge is the critical piece — take PR
+#198's parser (richer payloads) and add main's 4 canonical event aliases.
+
+## Scope
+
+What's in:
+- Add `EndpointConfig` support to `internal/httpclient/` (configurable API paths)
+- Add 4 canonical event aliases to `internal/sse/parse.go`:
+  - `message.delta` → `ChunkText`
+  - `message.complete` → `ChunkText` (done)
+  - `tool.start` → `ChunkToolStart`
+  - `tool.end` → `ChunkToolEnd`
+- Add `ListAgents` fallback: try `[]AgentSummary`, fall back to `[]string`
+- Enhance `StubClient` with main's richer version
+
+What's out:
+- Type changes (SB-059)
+- New transport implementations (SB-061)
+
+## Implementation
+
+**SSE parser merge** (`internal/sse/parse.go`):
+
+PR #198's `ChunkFromSSE` is the base — it has richer payload parsing:
+- `SSEToolStartData.Arguments` (`map[string]any`)
+- `SSEToolEndData.Result` (`any`) with fallback to `Output`
+- `ChunkToolReject`, `ChunkIteration` types
+
+Add main's aliases to the switch statement (~10 lines):
+```go
+case "message.delta":     // alias for agent.message.chunk
+case "message.complete":  // alias for agent.message.complete
+case "tool.start":        // alias for agent.tool.start
+case "tool.end":          // alias for agent.tool.end
+```
+
+**EndpointConfig** (`internal/httpclient/client.go`):
+
+From `packages/agent-tui/internal/httpclient/client.go`:
+```go
+type EndpointConfig struct {
+    ListAgents         string // default: "/agents"
+    CreateConversation string // default: "/conversations"
+    SendMessage        string // default: "/conversations/{id}/send"
+    ListConversations  string // default: "/conversations"
+    GetConversation    string // default: "/conversations/{id}"
+    Health             string // default: "/health"
+}
+```
+
+Replace hardcoded URL construction with config-driven paths.
+
+**ListAgents fallback**: Try unmarshaling as `[]AgentSummary` first. If that
+fails, try `[]string` and convert to `AgentSummary{ID: name, Name: name}`.
+
+Source: `packages/agent-tui/internal/httpclient/client.go`
+
+## Verification
+
+- [ ] `go test ./internal/sse/...` passes
+- [ ] `go test ./internal/httpclient/...` passes
+- [ ] SSE parser handles both `agent.message.chunk` and `message.delta` for the same event
+- [ ] SSE parser handles both `agent.tool.start` and `tool.start`
+- [ ] `EndpointConfig` with custom paths compiles and is wired through
+- [ ] `Arguments map[string]any` is preserved in `StreamChunk` for tool.start events
+- [ ] `Result` fallback to `Output` is preserved for tool.end events
+
+## Notes
+
+- The merge strategy is: PR #198 parser is base, main's aliases are additive
+- Do NOT replace PR #198's richer payload parsing with main's simplified version
+- `StubClient` source: `packages/agent-tui/internal/httpclient/stub.go`

--- a/docs/issues/sb-063-port-service-lifecycle.md
+++ b/docs/issues/sb-063-port-service-lifecycle.md
@@ -1,0 +1,64 @@
+---
+id: SB-063
+title: Port service lifecycle from main
+status: draft
+epic: EP-017
+depends_on: [SB-059]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 6
+created: 2026-04-09
+---
+
+# Port service lifecycle from main
+
+## Summary
+
+Update `internal/service/` to match main's version: rename `LocalService` to
+`ExecService` and incorporate any polish fixes. This is the smallest issue in
+the epic — the service abstraction is nearly identical between branches.
+
+## Scope
+
+What's in:
+- Rename `LocalService` → `ExecService` (if PR #198 still uses the old name)
+- Verify `ServiceManager` matches main's version
+- Verify `ServiceNode` interface is identical
+- Update imports to `internal/types` if needed
+
+What's out:
+- Public `ServiceNode` type alias (SB-060)
+- New service implementations
+
+## Implementation
+
+Source: `packages/agent-tui/internal/service/`
+
+```
+packages/agentic-tui/internal/service/
+  node.go       ← ServiceNode interface, ServiceStatus enum
+  local.go      ← ExecService (renamed from LocalService)
+  manager.go    ← ServiceManager
+```
+
+The `ExecService`:
+- Spawns backend via `exec.Command` with custom Env, Dir
+- Health checks via HTTP GET to configurable path (default `/health`)
+- Polls every 200ms, 30s timeout
+- Graceful shutdown: 5s grace → SIGKILL
+- Process group tracking for clean shutdown
+
+Compare PR #198's `service/` with main's and take the superset.
+
+## Verification
+
+- [ ] `go build ./internal/service/...` passes
+- [ ] `ServiceNode` interface matches main's version
+- [ ] `ExecService` (not `LocalService`) is the exported name
+- [ ] `ServiceManager.StartAll/StopAll/HealthSummary` methods exist
+
+## Notes
+
+- This is likely a very small diff — possibly just a rename
+- Check if PR #198 already uses `ExecService` name

--- a/docs/issues/sb-064-contract-tests-examples.md
+++ b/docs/issues/sb-064-contract-tests-examples.md
@@ -1,0 +1,107 @@
+---
+id: SB-064
+title: Contract tests, examples, PROTOCOL.md
+status: draft
+epic: EP-017
+depends_on: [SB-061, SB-062]
+branch:
+pr:
+stack: agentic-tui
+stack_index: 7
+created: 2026-04-09
+---
+
+# Contract tests, examples, PROTOCOL.md
+
+## Summary
+
+Add contract tests (validating HTTP and stdio backends), reference examples
+(showing all integration patterns), and PROTOCOL.md (the universal backend
+contract document). This is the capstone issue — everything should compile
+and all tests pass after this.
+
+## Scope
+
+What's in:
+- Copy `packages/agent-tui/contracttest/` → `packages/agentic-tui/contracttest/`
+- Copy `packages/agent-tui/_examples/` → `packages/agentic-tui/_examples/`
+- Update all import paths to `github.com/dugshub/agentic-tui`
+- Write `PROTOCOL.md` at package root
+- Final verification: `go build ./...` and `go test ./...` across entire package
+
+What's out:
+- CI/CD pipelines (post-epic ship task)
+- GitHub Release workflow (post-epic)
+- README.md (post-epic)
+- Stack Bench integration (post-epic)
+
+## Implementation
+
+**Contract tests** (`contracttest/`):
+
+Source: `packages/agent-tui/contracttest/`
+```
+packages/agentic-tui/contracttest/
+  validate.go         ← ValidateBackend() for HTTP/SSE
+  validate_stdio.go   ← ValidateStdioBackend() for JSON-RPC
+  validate_test.go    ← Test helpers
+```
+
+Update imports from `github.com/dugshub/agent-tui` → `github.com/dugshub/agentic-tui`.
+
+**Examples** (`_examples/`):
+
+Source: `packages/agent-tui/_examples/`
+```
+packages/agentic-tui/_examples/
+  minimal/main.go           ← 24-line HTTP integration
+  stdio-python/             ← Python JSON-RPC backend
+  stdio-typescript/         ← TypeScript JSON-RPC backend
+  custom-commands/main.go   ← Registering custom slash commands
+  custom-theme/main.go      ← Custom theme
+  demo/main.go              ← Demo mode
+  gallery/main.go           ← Component gallery
+```
+
+Update imports. Verify each example compiles: `go build ./_examples/minimal/`
+
+**PROTOCOL.md**:
+
+Contents (from spec):
+1. SSE event vocabulary with full JSON payload schemas
+2. JSON-RPC 2.0 method definitions (params, results, error codes)
+3. HTTP endpoint conventions (paths, methods, headers, SSE wire format)
+4. Display type registry (`generic`, `diff`, `code`, `bash`)
+5. Streaming lifecycle (connect → stream events → done/error)
+6. Backward compatibility guarantees (event name aliases, optional fields)
+7. "Implementing a backend in 30 minutes" quick-start
+
+Event table for PROTOCOL.md:
+
+| Event | Legacy Aliases | Data | Purpose |
+|-------|---------------|------|---------|
+| `message.delta` | `agent.message.chunk` | `{"delta": "..."}` | Streaming text |
+| `message.complete` | `agent.message.complete` | `{"content", "input_tokens", "output_tokens"}` | Message done |
+| `thinking` | `agent.reasoning` | `{"content": "..."}` | Reasoning |
+| `tool.start` | `agent.tool.start`, `tool_start` | `{"tool_call_id", "tool_name", "display_type", "arguments"}` | Tool begins |
+| `tool.end` | `agent.tool.end`, `tool_end` | `{"tool_call_id", "result", "error", "duration_ms", "display_type"}` | Tool ends |
+| `tool.rejected` | `agent.tool.rejected` | `{"tool_name", "reason"}` | Safety gate |
+| `error` | `agent.error` | `{"error_type", "message"}` | Fatal error |
+| `done` | -- | `{}` | Stream complete |
+
+## Verification
+
+- [ ] `go build ./...` passes (entire package including examples)
+- [ ] `go test ./...` passes (all tests)
+- [ ] `go vet ./...` passes
+- [ ] Each example compiles independently
+- [ ] `PROTOCOL.md` exists and covers all event types
+- [ ] Contract test for HTTP validates: listAgents, createConversation, sendMessage streaming
+- [ ] Contract test for stdio validates: listAgents, createConversation, sendMessage streaming
+- [ ] No imports reference `github.com/dugshub/agent-tui` (old module) or `github.com/dugshub/stack-bench`
+
+## Notes
+
+- This issue is the final gate — if all verification passes here, EP-017 is complete
+- The contract tests are helpers for backend implementors, not integration tests against a live backend
+- PROTOCOL.md is the document external developers will read first


### PR DESCRIPTION
## Summary
- Creates **EP-017** epic with 7 issues (SB-058 through SB-064) for the agentic-tui standalone package extraction
- Refines the spec: resolves all open questions, adds issue-to-phase mapping with dependency graph, removes post-epic ship phases
- Structured for `/orchestrate` — SB-058/059 are sequential foundation, SB-060-063 can run in parallel, SB-064 is the capstone

## Issues
| ID | Title | Depends On |
|----|-------|------------|
| SB-058 | Scaffold from PR #198 | -- |
| SB-059 | Unify types | SB-058 |
| SB-060 | Port public API | SB-059 |
| SB-061 | Port stdio client | SB-059 |
| SB-062 | Port HTTP enhancements | SB-059 |
| SB-063 | Port service lifecycle | SB-059 |
| SB-064 | Contract tests + examples + PROTOCOL.md | SB-061, SB-062 |

## Test plan
- [ ] All 8 files exist: 1 epic + 7 issues
- [ ] Spec phase table matches issue IDs
- [ ] Each issue has scope, implementation, and verification sections
- [ ] Dependency graph is consistent across epic and spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)