### PR TITLE
feat: local git adapter, project management, collapsible sidebar

### DIFF
--- a/.claude/specs/2026-04-09-local-git-adapter.md
+++ b/.claude/specs/2026-04-09-local-git-adapter.md
@@ -1,0 +1,465 @@
+---
+title: LocalGitAdapter — Read Diffs, Trees, and Files from Local Git Clones
+status: in-progress
+created: 2026-04-09
+depends_on: []
+---
+
+# LocalGitAdapter
+
+## Goal
+
+Build a `LocalGitAdapter` that implements `GitRepoProtocol` by running `git` commands against a local clone on disk, so stack-bench can serve diffs, file trees, and file content for workspaces that have a `local_path` without needing a GitHub token or API access. This enables reviewing stacks for work repos where the GitHub App is not installed.
+
+## Context
+
+### What exists
+
+- `GitRepoProtocol` (4 read-only methods) — `molecules/providers/github_adapter.py:65-74`
+- `GitHubAdapter` implements the protocol via GitHub REST API — same file, line 310+
+- Data models (`DiffData`, `DiffFile`, `DiffHunk`, `DiffLine`, `FileTreeNode`, `FileContent`) — same file, lines 17-56
+- `_parse_patch()` — unified-diff parser already works with raw git output (same file, line 166)
+- `_build_file_tree()` — builds recursive tree from flat entries (same file, line 202)
+- `_detect_language()` — extension-based language detection (same file, line 142)
+- `Workspace.local_path` field — `features/workspaces/models.py:38`
+- `StackAPI.__init__` takes `github: GitHubAdapter | None` — `molecules/apis/stack_api.py:49`
+- `StackEntity.get_branch_repo_context()` returns `(owner, repo, base_ref, head_ref)` — `molecules/entities/stack_entity.py:193`
+- `dependencies.py` creates `GitHubAdapter` concretely — `organisms/api/dependencies.py:89-141`
+- `CloneManager` and `GitOperations` use `asyncio.create_subprocess_exec` pattern — `molecules/services/clone_manager.py`
+- Backend runs locally (not Docker), so direct filesystem access to local clones is available
+
+### What's missing
+
+1. A `LocalGitAdapter` class that implements `GitRepoProtocol` via local `git` subprocess calls
+2. Shared location for data models (currently co-located with `GitHubAdapter`)
+3. Adapter selection logic at the DI layer — choose local vs. GitHub based on workspace config
+4. Type annotations updated from concrete `GitHubAdapter` to `GitRepoProtocol`
+5. Error types for local git failures (separate from GitHub API errors)
+
+### Design constraints
+
+- The 4 protocol methods accept `owner`/`repo` params. The local adapter ignores them (it already knows the repo path). This preserves the protocol contract without change.
+- Write operations (`create_pull_request`, `merge_pr`, `mark_pr_ready`, `update_pull_request`, `create_review_comment`, `list_review_comments`, `hydrate_stack`) are GitHub-only. The local adapter does not need them. `StackAPI` already guards these with `if self.github is None` checks and the type annotations use `GitHubAdapter` specifically for write paths.
+- The `_parse_patch` function already handles standard unified-diff format. `git diff` produces the same format as GitHub's patch field, so we reuse it directly.
+
+## Plan
+
+### Phase 1: Extract shared models into `git_types.py`
+
+**Files**:
+- New: `app/backend/src/molecules/providers/git_types.py`
+- Modified: `app/backend/src/molecules/providers/github_adapter.py`
+- Modified: all files that import DTOs from `github_adapter`
+
+**Changes**:
+
+Move these out of `github_adapter.py` into a new `git_types.py`:
+- `DiffLine`, `DiffHunk`, `DiffFile`, `DiffData`
+- `FileTreeNode`, `FileContent`
+- `GitRepoProtocol`
+- `_EXTENSION_LANGUAGE_MAP`, `_detect_language()`
+- `_parse_patch()`, `_HUNK_HEADER_RE`
+- `_build_file_tree()`
+- `_MAX_CONTENT_SIZE` constant
+
+`github_adapter.py` re-imports them from `git_types.py` for backward compatibility. The existing public API surface does not change — `from molecules.providers.github_adapter import DiffData` keeps working via re-export.
+
+**Why**: These types are protocol-level, not GitHub-specific. Keeping them in `github_adapter.py` would force `LocalGitAdapter` to import from a GitHub-named module. The shared module clarifies the boundary: types and parsing utilities are adapter-agnostic.
+
+**Import updates** (8 files):
+| File | Currently imports | Change to |
+|------|------------------|-----------|
+| `organisms/api/routers/stacks.py` | `DiffData, FileContent, FileTreeNode` from `github_adapter` | from `git_types` (or keep via re-export) |
+| `molecules/apis/stack_api.py` | `DiffData, FileContent, FileTreeNode, GitHubAdapter` (TYPE_CHECKING) | `DiffData, FileContent, FileTreeNode` from `git_types`; keep `GitHubAdapter` |
+| `molecules/apis/stack_api.py` | `parse_owner_repo` from `github_adapter` | stays (that function stays in `github_adapter`) |
+| `molecules/entities/stack_entity.py` | `parse_owner_repo, GitHubAdapter` | stays |
+| `organisms/api/error_handlers.py` | `GitHubAPIError, GitHubNotFoundError, GitHubRateLimitError` | stays (these are GitHub-specific) |
+| `organisms/api/app.py` | `GitHubAPIError` | stays |
+| `__tests__/molecules/test_github_adapter.py` | everything | most can come from `git_types`; `GitHubAdapter` and errors stay |
+| `__tests__/molecules/test_needs_restack.py` | `GitHubAdapter` | stays |
+
+Decision: Use re-exports in `github_adapter.py` so no import changes are required. Downstream code can optionally migrate to `git_types` imports over time, but nothing breaks either way.
+
+### Phase 2: Create `LocalGitAdapter`
+
+**Files**:
+- New: `app/backend/src/molecules/providers/local_git_adapter.py`
+
+**Class design**:
+
+```python
+class LocalGitError(Exception):
+    """Base error for local git operations."""
+    def __init__(self, message: str, returncode: int = 1):
+        super().__init__(message)
+        self.returncode = returncode
+
+class LocalGitRefNotFoundError(LocalGitError):
+    """A requested ref (branch, SHA) does not exist in the local repo."""
+
+class LocalGitAdapter:
+    """Implements GitRepoProtocol using local git subprocess calls."""
+
+    def __init__(self, repo_path: str) -> None:
+        self.repo_path = repo_path  # absolute path to the .git repo
+
+    async def _run(self, *args: str) -> str:
+        """Run a git command, return stdout. Raise LocalGitError on failure."""
+
+    # --- Protocol methods ---
+    async def get_diff(self, owner, repo, base_ref, head_ref) -> DiffData: ...
+    async def get_file_tree(self, owner, repo, ref) -> FileTreeNode: ...
+    async def get_file_content(self, owner, repo, ref, path) -> FileContent: ...
+    async def get_behind_count(self, owner, repo, base_ref, head_ref) -> int: ...
+```
+
+**Git command mappings**:
+
+| Protocol method | Git command | Notes |
+|----------------|-------------|-------|
+| `get_diff` | `git diff base_ref...head_ref` | Produces unified diff. Parse with `_parse_patch`. Use `--numstat` for per-file additions/deletions. Use `--diff-filter` + `--name-status` for change types. |
+| `get_file_tree` | `git ls-tree -r --long ref` | Outputs `mode type hash size\tpath` per line. Map `blob` to `file`, `tree` to `dir`. |
+| `get_file_content` | `git show ref:path` | Outputs raw file content. Check size with `git cat-file -s ref:path` first. |
+| `get_behind_count` | `git rev-list --count head_ref..base_ref` | Count of commits on base not on head. Note: `a..b` means "commits reachable from b but not a". |
+
+**Detailed implementation for each method**:
+
+#### `get_diff(owner, repo, base_ref, head_ref)`
+
+This needs three git commands to fully match GitHub's compare API output:
+
+1. `git diff --name-status base_ref...head_ref` — produces change types per file:
+   - `A` = added, `M` = modified, `D` = deleted, `R###` = renamed (with similarity %)
+2. `git diff --numstat base_ref...head_ref` — produces per-file `additions\tdeletions\tpath`
+   - Binary files show `-\t-\tpath` (handle gracefully: 0 additions, 0 deletions)
+3. `git diff base_ref...head_ref` — full unified diff, split by file header (`diff --git a/... b/...`)
+
+The three-dot `...` syntax is crucial: it means "diff between head_ref and the merge-base of base_ref and head_ref", which matches what GitHub shows for a PR diff. For a local two-dot diff, use `base_ref..head_ref` instead — but three-dot matches GitHub's behavior.
+
+Alternatively, combine into two commands:
+1. `git diff --numstat --diff-filter=ACDMRT base_ref...head_ref` (gives additions/deletions/change-type info via `--diff-filter`)
+2. `git diff base_ref...head_ref` (full patch)
+
+Actually the simplest approach is a single `git diff` call with combined flags, then parse the output:
+
+1. `git diff --name-status base_ref...head_ref` — for change types
+2. `git diff base_ref...head_ref` — for the full patch
+
+Parse the full patch by splitting on `diff --git a/... b/...` boundaries. For each file, extract the patch portion and pass it to the existing `_parse_patch()`. For binary files, there will be no patch text — produce empty hunks.
+
+For additions/deletions counts, rather than running `--numstat`, count from the parsed hunks (lines with `type="add"` and `type="del"`). This avoids a third subprocess call and the data is already parsed.
+
+**Edge cases**:
+- **Binary files**: `git diff` emits `Binary files a/X and b/X differ` instead of a patch. Detect this line, set additions=0, deletions=0, hunks=[].
+- **Renamed files**: `--name-status` outputs `R100\told\tnew`. Map to `change_type="renamed"`, use the new path.
+- **Large diffs**: Git output can be arbitrarily large. Set a reasonable buffer size or stream-parse. For MVP, read full output into memory (matching GitHub adapter behavior).
+- **Missing refs**: If a branch hasn't been fetched, `git diff` fails with exit code 128. Catch this and raise `LocalGitRefNotFoundError`.
+- **Empty diffs**: `git diff` produces no output when there are no changes. Return `DiffData(files=[], total_additions=0, total_deletions=0)`.
+
+#### `get_file_tree(owner, repo, ref)`
+
+Single command: `git ls-tree -r --long ref`
+
+Output format per line: `<mode> <type> <hash> <size>\t<path>`
+
+Example:
+```
+100644 blob abc1234    150	src/main.py
+100644 blob def5678     42	README.md
+```
+
+Note: `-r` recurses into subtrees but only lists blobs (not tree entries). Directories are implied by paths. This is similar to how GitHub's flat tree array works — use `_build_file_tree()` directly. But we need to produce the same entry format:
+
+```python
+entries = [{"path": path, "type": "blob", "size": size} for each line]
+```
+
+Then call `_build_file_tree(entries)` which already handles implicit parent directory creation.
+
+**Edge cases**:
+- **Empty repo / empty tree at ref**: `git ls-tree` returns nothing. Return root node with empty children.
+- **Submodules**: `ls-tree` shows them as `commit` type (mode 160000). Skip these or represent as a special node. For MVP, skip.
+- **Symlinks**: mode 120000 — include as regular files.
+
+#### `get_file_content(owner, repo, ref, path)`
+
+Two commands:
+1. `git cat-file -s ref:path` — get size in bytes (before reading content, to check against `_MAX_CONTENT_SIZE` and detect missing files)
+2. `git show ref:path` — get raw content
+
+**Edge cases**:
+- **Binary files**: `git show` outputs raw binary. Detect via null bytes in first 8KB, or by checking if the file is in `.gitattributes` as binary. For MVP, attempt UTF-8 decode with `errors="replace"`.
+- **Large files**: If `cat-file -s` returns size > `_MAX_CONTENT_SIZE`, still read but truncate to the constant (matching GitHub adapter behavior).
+- **Missing path**: `git show ref:path` exits with code 128. Raise `LocalGitRefNotFoundError`.
+- **Empty files**: Return `FileContent(path=path, content="", size=0, language=..., lines=0, truncated=False)`.
+
+#### `get_behind_count(owner, repo, base_ref, head_ref)`
+
+Single command: `git rev-list --count head_ref..base_ref`
+
+This counts commits reachable from `base_ref` but not from `head_ref`, which is exactly GitHub's `behind_by` metric.
+
+**Edge cases**:
+- **Same ref**: Returns "0". Handle normally.
+- **Unrelated histories**: `rev-list` still works, just shows all commits on base. Acceptable behavior.
+- **Missing ref**: Exit code 128. Raise `LocalGitRefNotFoundError`.
+
+**Caching**: Unlike the GitHub adapter, the local adapter should NOT cache aggressively. Local files change in real-time. However, we can cache based on ref SHA (if the ref is a full SHA, the content is immutable). For branch names, skip caching or use a very short TTL (e.g., 5 seconds). For MVP, no caching — local git commands are fast (sub-100ms).
+
+### Phase 3: Update type annotations to use the protocol
+
+**Files**:
+- Modified: `app/backend/src/molecules/apis/stack_api.py`
+- Modified: `app/backend/src/molecules/entities/stack_entity.py`
+
+**Changes in `stack_api.py`**:
+
+The `StackAPI` class has two distinct dependency needs:
+1. **Read operations** (`get_branch_diff`, `get_branch_tree`, `get_branch_file`, `get_stack_detail`): Need `GitRepoProtocol` — either adapter works.
+2. **Write operations** (`submit_stack`, `ready_stack`, `merge_stack`): Need `GitHubAdapter` specifically — only GitHub can create/merge PRs.
+
+Refactor `StackAPI.__init__` to accept both:
+
+```python
+def __init__(
+    self,
+    db: AsyncSession,
+    git_reader: GitRepoProtocol | None = None,
+    github: GitHubAdapter | None = None,
+) -> None:
+```
+
+Where:
+- `git_reader` is used by all read operations (diff, tree, file, behind_count)
+- `github` is used by write operations (submit, ready, merge, create_review_comment)
+- If only `github` is provided (backward-compatible path), use it as both reader and writer
+- If only `git_reader` is provided, reads work but writes raise RuntimeError
+
+Alternatively (simpler and less disruptive): keep a single `github` param but change its type annotation:
+
+```python
+def __init__(
+    self,
+    db: AsyncSession,
+    github: GitRepoProtocol | None = None,
+) -> None:
+```
+
+Read operations use `self.github` through the protocol interface. Write operations do a runtime `isinstance(self.github, GitHubAdapter)` check. This keeps the constructor signature change minimal.
+
+**Decision**: Use the two-param approach. It is more explicit, makes the read-vs-write capability visible in the type system, and does not require `isinstance` checks. However, to minimize disruption in Phase 3, start with the simpler single-param approach and upgrade to two-param in a follow-up if needed.
+
+Actually, the cleanest approach for Phase 3:
+
+1. Add a `git_reader` property that returns whichever adapter is available for reading.
+2. Keep `github` for writes, with its concrete type.
+
+```python
+class StackAPI:
+    def __init__(
+        self,
+        db: AsyncSession,
+        github: GitHubAdapter | None = None,
+        git_reader: GitRepoProtocol | None = None,
+    ) -> None:
+        self.db = db
+        self.entity = StackEntity(db)
+        self.github = github
+        self._git_reader = git_reader
+        self._comment_svc = ReviewCommentService()
+
+    @property
+    def reader(self) -> GitRepoProtocol | None:
+        """Resolve the best available reader: explicit reader, or fall back to github."""
+        return self._git_reader or self.github
+```
+
+Then read methods use `self.reader` instead of `self.github`. Write methods continue using `self.github`. Error messages update: "Git reader not configured" for reads, "GitHub adapter required for write operations" for writes.
+
+**Changes in `stack_entity.py`**:
+
+`submit_stack` and `ready_stack` accept `github: GitHubAdapter` — these stay as-is. They only need the write-capable GitHub adapter.
+
+`get_branch_repo_context()` currently parses `workspace.repo_url` into `(owner, repo)`. For local adapter, this context resolution changes:
+- The local adapter ignores `owner`/`repo` — it uses `repo_path` directly.
+- The `owner` and `repo` values still need to flow through for GitHub write operations.
+- The method can return dummy values when `local_path` is set and no `repo_url` is available.
+- But actually, `repo_url` is a required field on Workspace, so it always exists. And `parse_owner_repo` will work on it. The local adapter just ignores those values. No change needed in `get_branch_repo_context`.
+
+### Phase 4: Adapter selection — Final Design
+
+**No DI layer changes needed.** Adapter selection happens per-workspace inside `StackAPI`.
+
+The adapter choice depends on the *workspace* (which has `local_path`), not the user. A user might have multiple workspaces: some with `local_path`, some without. The resolution point is when a branch is being queried, because that's when we know which workspace is involved.
+
+The DI layer continues to provide `GitHubAdapter | None` as today. `StackAPI` gains a `_get_reader_for_branch` method that resolves the best adapter lazily:
+
+```python
+async def _get_reader_for_branch(self, branch_id: UUID) -> GitRepoProtocol:
+    """Resolve the best git reader for a specific branch's workspace.
+
+    Priority: local_path (if exists and is a git repo) > GitHubAdapter > error.
+    """
+    branch = await self.entity.get_branch(branch_id)
+    workspace = await self.entity.workspace_service.get(self.db, branch.workspace_id)
+    if workspace is None:
+        raise BranchNotFoundError(branch_id)
+
+    # Prefer local if available and is a valid git repo
+    if workspace.local_path:
+        repo_path = Path(workspace.local_path)
+        if repo_path.is_dir() and (repo_path / ".git").exists():
+            from molecules.providers.local_git_adapter import LocalGitAdapter
+            return LocalGitAdapter(workspace.local_path)
+
+    # Fall back to GitHub
+    if self.github is not None:
+        return self.github
+
+    raise RuntimeError("No git reader available: workspace has no local_path and no GitHub adapter configured")
+```
+
+Read methods (`get_branch_diff`, `get_branch_tree`, `get_branch_file`) use `self._get_reader_for_branch(branch_id)`. Write methods (`submit_stack`, `ready_stack`, `merge_stack`) continue using `self.github` directly.
+
+**`_compute_restack_flags` note**: The existing guard (`if self.github is not None`) means local-only workspaces will show `needs_restack = false` for all branches. This is acceptable — restack detection from local git can be added later.
+
+The diff/tree/file endpoints already use `StackAPIDep` (not `UserStackAPIDep`), so they work with or without a GitHub token. No dependency changes needed.
+
+### Phase 5: Error handling
+
+**Files**:
+- Modified: `app/backend/src/organisms/api/error_handlers.py`
+- Modified: `app/backend/src/organisms/api/app.py`
+
+**Changes**: Register a handler for `LocalGitError`:
+
+```python
+async def local_git_exception_handler(request: Request, exc: LocalGitError) -> JSONResponse:
+    if isinstance(exc, LocalGitRefNotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    return JSONResponse(status_code=500, content={"detail": f"Local git error: {exc}"})
+```
+
+### Phase 6: Tests
+
+**Files**:
+- New: `app/backend/__tests__/molecules/test_local_git_adapter.py`
+
+**Test strategy**:
+
+Unit tests that mock `asyncio.create_subprocess_exec` to simulate git command output. This matches the project's existing pattern — the GitHub adapter tests mock `httpx`, the local adapter tests mock subprocess.
+
+Test cases:
+
+**`get_diff` tests**:
+- Simple modification (one file changed)
+- Multiple files with mixed change types (added, modified, deleted, renamed)
+- Binary file (no patch, `Binary files ... differ`)
+- Empty diff (no changes between refs)
+- Missing ref (exit code 128 -> `LocalGitRefNotFoundError`)
+- Diff with multiple hunks per file
+- File with only additions (new file)
+- File with only deletions (deleted file)
+
+**`get_file_tree` tests**:
+- Flat file list
+- Nested directories (implicit parent creation)
+- Empty tree
+- Files with sizes
+
+**`get_file_content` tests**:
+- Normal text file
+- Large file (truncation at `_MAX_CONTENT_SIZE`)
+- Missing file (exit 128 -> error)
+- Empty file
+- Language detection
+
+**`get_behind_count` tests**:
+- Normal count (returns integer)
+- Zero (same ref / up to date)
+- Missing ref (error)
+
+**Integration test** (optional, marked `@pytest.mark.integration`):
+- Create a temp git repo with known commits, run actual `LocalGitAdapter` against it
+- Verify diff output matches expected structure
+- This proves the git command parsing works end-to-end without mocks
+
+**`_get_reader_for_branch` tests** (in `test_stack_api.py` or new file):
+- Workspace with `local_path` that exists -> returns `LocalGitAdapter`
+- Workspace with `local_path` that does not exist -> falls back to `GitHubAdapter`
+- Workspace with no `local_path` -> uses `GitHubAdapter`
+- Workspace with no `local_path` and no GitHub adapter -> raises `RuntimeError`
+
+## Implementation Phases
+
+| Phase | What | Depends On | Risk |
+|-------|------|------------|------|
+| 1 | Extract shared types to `git_types.py` | -- | Low — pure refactor with re-exports |
+| 2 | Create `LocalGitAdapter` class | Phase 1 | Medium — git output parsing |
+| 3 | Update `StackAPI` to resolve adapter per-workspace | Phase 2 | Low — additive change |
+| 4 | Update DI layer (if needed) | Phase 3 | Low — minimal changes |
+| 5 | Error handling | Phase 2 | Low |
+| 6 | Tests | Phase 2 | Low |
+
+Phases 5 and 6 can run in parallel with Phase 3-4.
+
+## File Tree
+
+```
+app/backend/src/
+  molecules/providers/
+    git_types.py                    # NEW: shared DTOs, protocol, parsing utils
+    local_git_adapter.py            # NEW: LocalGitAdapter class
+    github_adapter.py               # MODIFIED: re-export from git_types
+    __init__.py                     # MODIFIED: export LocalGitAdapter
+  molecules/apis/
+    stack_api.py                    # MODIFIED: _get_reader_for_branch, read methods
+  organisms/api/
+    error_handlers.py               # MODIFIED: LocalGitError handler
+    app.py                          # MODIFIED: register handler
+
+app/backend/__tests__/
+  molecules/
+    test_local_git_adapter.py       # NEW: unit tests
+    test_stack_api_reader.py        # NEW: reader resolution tests
+```
+
+## Key Design Decisions
+
+### 1. Adapter resolves per-workspace, not per-user
+
+The local adapter is tied to a workspace's `local_path`, not to the user. This means the same user can have some workspaces using local git and others using GitHub. The resolution happens inside `StackAPI._get_reader_for_branch()`, not at the DI injection point.
+
+**Alternative considered**: Inject the adapter at the DI level based on a header or config flag. Rejected because the adapter choice depends on workspace-level data that's only available after loading the branch.
+
+### 2. Re-export from `github_adapter.py` for backward compatibility
+
+Rather than updating all import sites in Phase 1, `github_adapter.py` re-exports everything from `git_types.py`. This makes Phase 1 a zero-risk refactor — existing code continues to work without changes. Import sites can migrate to `git_types` over time.
+
+### 3. No caching in `LocalGitAdapter`
+
+GitHub API calls are rate-limited and slow (network round-trip). Local git commands are fast (sub-100ms). Adding caching would introduce staleness bugs — the user might amend a commit and the diff would be stale. Skip caching entirely for local operations.
+
+### 4. `owner`/`repo` params are ignored but accepted
+
+The protocol requires them. The local adapter accepts and discards them. This avoids changing the protocol interface, which would require changes to both adapters and all callers. The local adapter's `__init__` takes the `repo_path` which is all it needs.
+
+### 5. Three-dot diff (`base...head`) not two-dot
+
+`git diff base...head` computes the diff from the merge-base, matching what GitHub shows for PRs. `git diff base..head` would show all changes between the two refs including changes on the base branch since the fork point. We want the former.
+
+### 6. Separate error hierarchy from GitHub errors
+
+`LocalGitError` is distinct from `GitHubAPIError`. They share no inheritance. This prevents confusion at the error handler level and keeps error messages clear about what failed (local subprocess vs. API call).
+
+## Open Questions
+
+1. **Fetch before diff?** If the local repo hasn't been fetched recently, remote branches may be stale. Should the adapter run `git fetch` before operations? Recommendation: No — let the user manage their local repo. The adapter is read-only and fast. Adding implicit fetches would be slow and surprising.
+
+2. **Submodule handling**: `git ls-tree` shows submodules as `commit` type entries. Should we include them in the file tree? Recommendation: Skip for MVP, add later if needed.
+
+3. **Worktree support**: Should `local_path` point to a worktree or the main repo? `git` commands work transparently in worktrees, so no special handling needed. Document that `local_path` can be either.
+
+4. **Concurrent access**: Multiple requests may hit the local adapter simultaneously. `git` commands are safe to run concurrently against the same repo (they use lock files internally). No mutex needed.
+
+5. **Renamed file path in diff**: `git diff --name-status` shows `R100\told\tnew`. Which path should we use in `DiffFile.path`? Recommendation: Use the new path (matching GitHub's behavior), and optionally add an `old_path` field to `DiffFile` later.

--- a/.claude/specs/2026-04-09-project-setup-flow.md
+++ b/.claude/specs/2026-04-09-project-setup-flow.md
@@ -1,0 +1,336 @@
+---
+title: Project Setup Flow — Switcher, Creation, Auto-Workspace
+date: 2026-04-09
+status: in-progress
+branch: null
+depends_on: []
+adrs: []
+---
+
+# Project Setup Flow — Switcher, Creation, Auto-Workspace
+
+## Goal
+
+Add a complete project management flow to the frontend so users can create projects (especially pointing at local git repos), switch between them, and have workspaces auto-created. Today the sidebar hardcodes `projects[0]?.id`, there is no creation UI, and projects must be inserted via SQL. This work unblocks the LocalGitAdapter by giving users a way to create projects with `local_path`.
+
+## Domain Model
+
+No new backend models needed. The existing entities and their patterns:
+
+| Entity | Pattern | Role in this feature |
+|--------|---------|---------------------|
+| `Project` | EventPattern (setup -> active -> archived) | Created by the new form, listed in the switcher |
+| `Workspace` | EventPattern (created -> provisioning -> ready -> ...) | Auto-created alongside the project |
+| `User` | ActorPattern | `owner_id` for project, available via `useAuth().user.id` |
+
+Key relationships:
+- Project has `owner_id` FK to User
+- Workspace has `project_id` FK to Project
+- A local project needs both a Project (`local_path`, `github_repo`) and a Workspace (`local_path`, `repo_url`, `provider`)
+
+## Current State Analysis
+
+### Backend — ready, with one required change
+
+The `POST /api/v1/projects/` endpoint works. The `ProjectCreate` schema requires `github_repo` as a validated GitHub URL. For local-only projects, we need to either:
+- **(A) Make `github_repo` optional** in the backend schema and model (breaking change to the DB constraint)
+- **(B) Derive `github_repo` from the git remote** in a new molecule-layer endpoint that accepts `local_path` and reads the remote URL
+- **(C) Create a new composite endpoint** (`POST /api/v1/projects/setup`) that accepts `name` + `local_path`, reads the git remote origin, and creates both project and workspace in one transaction
+
+**Decision: Option C** — a new molecule-layer workflow + organism endpoint. This keeps the existing `ProjectCreate` schema untouched, adds the composite logic in the correct layer (molecule), and gives the frontend a single API call for the common case. The existing raw CRUD endpoints remain for GitHub-based projects.
+
+### Frontend — needs project context + UI
+
+Three places hardcode `projects[0]?.id`:
+1. `GlobalSidebar.tsx` line 92
+2. `DashboardPage.tsx` line 63
+3. `StacksListPage.tsx` line 41
+
+These all need to read from a shared "active project" context instead.
+
+### Generated schemas — codegen gap
+
+The generated `ProjectCreateSchema` in `app/frontend/src/generated/schemas/project.ts` is missing `owner_id`, `github_repo`, and `local_path`. However, since we are adding a new composite endpoint (`/projects/setup`), we will create a manual TypeScript type for that endpoint's payload rather than fighting the codegen. The generated hooks remain useful for listing/getting projects.
+
+## Implementation Phases
+
+| Phase | What | Depends On |
+|-------|------|------------|
+| 1 | Backend: project setup workflow + endpoint | -- |
+| 2 | Frontend: active project context | -- |
+| 3 | Frontend: project switcher in sidebar | Phase 2 |
+| 4 | Frontend: "Add Project" dialog | Phase 2 |
+| 5 | Frontend: empty state + zero-project flow | Phases 3, 4 |
+
+## Phase Details
+
+### Phase 1: Backend — Project Setup Workflow + Endpoint
+
+Create a molecule-layer workflow that composes ProjectService and WorkspaceService to handle local project creation in one transaction.
+
+**Pre-requisite: Add `"local"` to workspace provider choices**
+
+The workspace model's `provider` field has `choices=["github", "gitlab", "bitbucket"]` and the schema uses `Literal["github", "gitlab", "bitbucket"]`. There is no DB check constraint (verified — only PK and FK constraints on the workspaces table), so no migration is needed. Changes:
+- `app/backend/src/features/workspaces/models.py` line 36: add `"local"` to choices list
+- `app/backend/src/features/workspaces/schemas/input.py` line 12: add `"local"` to Literal in `WorkspaceCreate`
+- `app/backend/src/features/workspaces/schemas/input.py` line 25: add `"local"` to Literal in `WorkspaceUpdate`
+
+**New file: `app/backend/src/molecules/workflows/project_setup.py`**
+
+Reference: `OnboardingWorkflow` at `molecules/workflows/onboarding.py` lines 209-265 for the identical pattern (create project + workspace in one transaction).
+
+```
+ProjectSetupWorkflow
+  - create_local_project(db, user_id, name, local_path, description?) -> ProjectSetupResult
+    1. Validate local_path exists and has a .git directory
+    2. Read git remote origin URL:
+       a. Run `git -C {local_path} remote get-url origin`
+       b. If remote exists: use it as github_repo and repo_url; set provider="github" (or detect from URL)
+       c. If no remote (command fails): use synthetic `https://github.com/local/{folder_name}` for github_repo;
+          set provider="local"; set repo_url to the same synthetic URL
+    3. Read default branch: `git -C {local_path} symbolic-ref --short HEAD` (fallback: "main")
+    4. Create Project via ProjectService (owner_id=user_id, github_repo from step 2)
+    5. Create Workspace with local_path, provider from step 2, repo_url from step 2
+    6. Transition project to "active"
+    7. Return {project_id, workspace_id, project_name}
+```
+
+**New file: `app/backend/src/organisms/api/routers/project_setup.py`**
+
+```
+Router prefix: "/projects" (same as existing projects router — the route is /setup under it)
+Alternatively: separate router with prefix "/projects/setup" — either works since "setup" is not a valid UUID
+
+POST /api/v1/projects/setup
+  Body: { name: str, local_path: str, description?: str }
+  Auth: CurrentUser (injects owner_id server-side)
+  Response: { project_id, workspace_id, project_name }
+```
+
+This endpoint uses `CurrentUser` dependency so the frontend never needs to send `owner_id` — it is derived from the JWT token.
+
+**Files to create:**
+- `app/backend/src/molecules/workflows/project_setup.py` — workflow
+- `app/backend/src/organisms/api/routers/project_setup.py` — router
+
+**Files to modify:**
+- `app/backend/src/features/workspaces/models.py` — add `"local"` to provider choices
+- `app/backend/src/features/workspaces/schemas/input.py` — add `"local"` to provider Literal types
+- `app/backend/src/organisms/api/app.py` — register new router
+
+### Phase 2: Frontend — Active Project Context
+
+Create a React context that tracks which project is active and persists the selection to `localStorage`. Every component that needs a project ID reads from this context instead of hardcoding `projects[0]`.
+
+**New file: `app/frontend/src/contexts/ProjectContext.tsx`**
+
+```tsx
+ProjectProvider
+  - Wraps AppLayout inside AppRouter.tsx (inside AuthGate, where QueryClientProvider + auth are available)
+  - Fetches project list via useProjectList()
+  - Reads saved project ID from localStorage
+  - If saved ID not found in list, falls back to projects[0]
+  - Exposes: { activeProject, setActiveProject, projects, isLoading }
+
+useActiveProject() hook
+  - Returns { activeProject, setActiveProject, projects, isLoading }
+  - Throws if used outside provider
+```
+
+**Files to create:**
+- `app/frontend/src/contexts/ProjectContext.tsx` — context + provider + hook
+
+**Files to modify:**
+- `app/frontend/src/main.tsx` or `app/frontend/src/AppRouter.tsx` — wrap with `ProjectProvider` (inside QueryClientProvider, since it needs react-query)
+- `app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx` — replace `projects[0]?.id` with `useActiveProject().activeProject?.id`
+- `app/frontend/src/pages/DashboardPage.tsx` — same replacement
+- `app/frontend/src/pages/StacksListPage.tsx` — same replacement
+
+The context should live inside the authenticated route tree (after `AuthGate`) since it needs the auth token for API calls. Placement: wrap `AppLayout` inside `AppRouter.tsx`.
+
+### Phase 3: Frontend — Project Switcher in Sidebar
+
+Add a dropdown/popover at the top of `GlobalSidebar` that shows all projects and lets the user switch between them.
+
+**Design:**
+- Replace the static "Stack Bench" header with a clickable project selector
+- Shows current project name with a chevron-down icon
+- On click, opens a dropdown listing all projects with their names
+- Active project gets a check mark or highlight
+- Bottom of dropdown: "Add Project" button that opens the creation dialog
+- Fits within 260px sidebar width
+
+**Component location** (atomic design): This is a molecule — it composes atoms (Icon, Button) and reads from context. However, since it is tightly coupled to the sidebar organism, it can live as an internal component within the `GlobalSidebar` directory.
+
+**Files to create:**
+- `app/frontend/src/components/organisms/GlobalSidebar/ProjectSwitcher.tsx` — the dropdown component
+
+**Files to modify:**
+- `app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx` — replace header section with `ProjectSwitcher`
+
+**Icon additions:** The Icon atom already has `chevron-down`, `check`, `plus`, and `folder` — all sufficient for the switcher.
+
+### Phase 4: Frontend — "Add Project" Dialog
+
+A modal dialog for creating a new project. Since no modal/dialog infrastructure exists in the codebase, we need to create a reusable dialog atom first.
+
+**Reusable Dialog atom:**
+
+**New file: `app/frontend/src/components/atoms/Dialog/Dialog.tsx`**
+
+- Renders a portal-based modal overlay
+- Handles ESC to close, click-outside to close
+- Accepts `isOpen`, `onClose`, `title`, `children`
+- Uses CSS variables for theming
+- Focus trap for accessibility
+
+**New file: `app/frontend/src/components/atoms/Dialog/index.ts`**
+
+- Export Dialog
+
+**Update: `app/frontend/src/components/atoms/index.ts`**
+
+- Add Dialog export
+
+**Add Project Form:**
+
+**New file: `app/frontend/src/components/organisms/AddProjectDialog/AddProjectDialog.tsx`**
+
+Form fields:
+1. **Name** (text input, required) — auto-derived from folder name if local_path is entered first
+2. **Local Path** (text input, required) — the main use case; placeholder: `/Users/you/Projects/my-repo`
+3. **Description** (text area, optional)
+
+Behavior:
+- On submit, calls `POST /api/v1/projects/setup` with `{ name, local_path, description }`
+- Shows validation errors inline (path doesn't exist, name taken, etc.)
+- On success: sets the new project as active via `setActiveProject()`, closes dialog
+- Loading state on submit button
+
+**New file: `app/frontend/src/components/organisms/AddProjectDialog/index.ts`**
+
+**New file: `app/frontend/src/hooks/useCreateLocalProject.ts`**
+
+Custom hook wrapping the mutation for `POST /api/v1/projects/setup`:
+```tsx
+function useCreateLocalProject() {
+  // useMutation calling apiClient.post('/api/v1/projects/setup', data)
+  // On success: invalidate project list queries
+}
+```
+
+**Files to modify:**
+- `app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx` — add dialog trigger state and render `AddProjectDialog`
+
+### Phase 5: Frontend — Empty State + Zero-Project Flow
+
+When a user has zero projects (fresh account, post-onboarding), the app needs to guide them to create one.
+
+**DashboardPage empty state:**
+- If `activeProject` is null and projects list is empty, show a centered empty state with:
+  - "No projects yet" heading
+  - "Create a project to start working with your code" subtitle
+  - "Add Project" button that opens the same `AddProjectDialog`
+
+**GlobalSidebar with no project:**
+- The project switcher shows "No project selected" or "Add a project"
+- Active tasks and stacks sections are hidden (they require a projectId)
+
+**Files to modify:**
+- `app/frontend/src/pages/DashboardPage.tsx` — add empty state before kanban
+- `app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx` — conditional rendering when no active project
+
+## File Tree
+
+```
+# NEW FILES
+app/backend/src/molecules/workflows/project_setup.py     # Workflow: create project + workspace from local path
+app/backend/src/organisms/api/routers/project_setup.py    # Router: POST /api/v1/projects/setup
+
+app/frontend/src/contexts/ProjectContext.tsx               # Active project context + provider + hook
+app/frontend/src/hooks/useCreateLocalProject.ts            # Mutation hook for /projects/setup
+app/frontend/src/components/atoms/Dialog/Dialog.tsx        # Reusable modal dialog atom
+app/frontend/src/components/atoms/Dialog/index.ts          # Dialog barrel export
+app/frontend/src/components/organisms/GlobalSidebar/ProjectSwitcher.tsx  # Project dropdown in sidebar
+app/frontend/src/components/organisms/AddProjectDialog/AddProjectDialog.tsx  # Project creation form dialog
+app/frontend/src/components/organisms/AddProjectDialog/index.ts             # Barrel export
+
+# MODIFIED FILES
+app/backend/src/organisms/api/app.py                      # Register project_setup router
+app/frontend/src/AppRouter.tsx                             # Wrap AppLayout with ProjectProvider
+app/frontend/src/components/atoms/index.ts                 # Export Dialog
+app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx  # Use ProjectContext, add switcher + dialog
+app/frontend/src/pages/DashboardPage.tsx                   # Use ProjectContext, add empty state
+app/frontend/src/pages/StacksListPage.tsx                  # Use ProjectContext
+```
+
+## Implementation Order
+
+1. **Phase 1** (backend) — standalone, no dependencies
+2. **Phase 2** (project context) — standalone frontend, no dependencies
+3. **Phase 3** (project switcher) — needs Phase 2 context
+4. **Phase 4** (add project dialog) — needs Phase 2 context + Phase 1 endpoint
+5. **Phase 5** (empty states) — needs Phases 3 + 4
+
+Phases 1 and 2 can be built in parallel.
+
+## Key Design Decisions
+
+### Why a new composite endpoint instead of fixing `github_repo` required constraint
+
+The `github_repo` field is `required=True` on both the model and schema. Making it optional would require a migration, updating the output schema, and handling nullability across the codebase. A composite endpoint avoids this entirely — it reads the git remote to populate `github_repo` automatically. If there is no remote, it constructs a synthetic `https://github.com/local/{repo-name}` URL as a placeholder. This is pragmatic: every local git repo that was cloned from GitHub already has the correct remote URL.
+
+### Why localStorage for active project persistence (not URL params)
+
+The active project is a session-level concern, not a page-level concern. It persists across navigation between dashboard, stacks, and workspaces. URL params would either clutter every route (`/stacks?project=abc`) or require complex route nesting (`/projects/:id/stacks`). localStorage + React context is simpler, matches how the auth token is already persisted, and survives page refreshes.
+
+### Why a Dialog atom instead of using a library
+
+The codebase has zero dependencies on component libraries (no Radix, no shadcn, no Headless UI). Every atom is hand-built with CSS variables. Adding a modal library for one dialog would be inconsistent. A custom Dialog atom (~60 lines) with portal, ESC handling, and overlay is trivial and follows the existing pattern.
+
+### Why the owner_id is injected server-side
+
+The current project create endpoint requires `owner_id` in the request body, which means the frontend must send the user's UUID. The new `/projects/setup` endpoint uses the `CurrentUser` FastAPI dependency to inject `owner_id` from the JWT token. This is more secure (users cannot create projects owned by other users) and simpler for the frontend.
+
+### Why workspace auto-creation matters
+
+The `StackAPI._get_reader_for_branch()` method resolves the git reader by checking `workspace.local_path`. Without a workspace, there is no way for the stack system to serve diffs or files for a project. Auto-creating a workspace when the project is created ensures the git pipeline works immediately.
+
+## Testing Strategy
+
+### Backend Tests
+
+**File: `app/backend/__tests__/test_project_setup.py`**
+
+- **Unit tests for `ProjectSetupWorkflow`:**
+  - Happy path: valid local_path with git remote -> creates project + workspace + transitions to active
+  - Local path with no remote -> uses synthetic github_repo URL
+  - Local path that doesn't exist -> raises validation error
+  - Local path that isn't a git repo -> raises validation error
+  - Duplicate project name -> raises error
+  - Marker: `@pytest.mark.asyncio`
+
+- **API integration tests:**
+  - `POST /api/v1/projects/setup` with valid payload -> 201, returns project_id + workspace_id
+  - Missing auth token -> 401
+  - Invalid local_path -> 422 validation error
+  - Marker: `@pytest.mark.asyncio`
+
+### Frontend Tests
+
+No formal test framework appears to be set up for the frontend (no `vitest.config.ts` or `jest.config.ts` found). Manual testing plan:
+
+1. **Zero-project state:** New user sees empty state on dashboard, can create project
+2. **Create project:** Fill in name + local path, submit -> project appears in switcher, auto-selected
+3. **Project switching:** Create two projects, switch between them -> dashboard/stacks update
+4. **Persistence:** Switch to project B, refresh page -> project B still selected
+5. **Validation:** Submit form with empty name or invalid path -> inline errors shown
+6. **Dialog UX:** ESC closes dialog, clicking overlay closes dialog, focus trapped inside
+
+## Open Questions
+
+1. **Should we also add a "GitHub repo" project creation path in this same dialog?** The onboarding flow already handles GitHub projects, but that flow is only for first-time setup. A second tab or mode in the dialog for "Import from GitHub" would be useful but could be deferred to a follow-up.
+
+2. **Should the project switcher show project state (setup/active/archived)?** Probably yes for archived projects (greyed out), but setup projects should auto-transition to active via the new endpoint, so they should rarely appear.
+
+3. **Should we add a "Settings" page for the active project?** This would show project details, workspace status, allow editing name/description, and eventually manage GitHub app integration. Not in scope for this spec but a natural follow-up.

--- a/app/backend/__tests__/molecules/test_local_git_adapter.py
+++ b/app/backend/__tests__/molecules/test_local_git_adapter.py
@@ -1,0 +1,393 @@
+"""Unit tests for LocalGitAdapter -- subprocess-based git operations.
+
+All tests mock asyncio.create_subprocess_exec to simulate git command output.
+This matches the project's pattern: GitHub adapter tests mock httpx,
+local adapter tests mock subprocess.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from molecules.providers.git_types import DiffData, FileContent, FileTreeNode
+from molecules.providers.local_git_adapter import (
+    LocalGitAdapter,
+    LocalGitError,
+    LocalGitRefNotFoundError,
+)
+
+
+def _make_process(stdout: str = "", stderr: str = "", returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess that returns the given stdout/stderr."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
+    proc.returncode = returncode
+    return proc
+
+
+def _adapter(repo_path: str = "/tmp/test-repo") -> LocalGitAdapter:
+    return LocalGitAdapter(repo_path)
+
+
+# ---------------------------------------------------------------------------
+# _run helper
+# ---------------------------------------------------------------------------
+
+
+class TestRun:
+    @pytest.mark.unit
+    async def test_returns_stdout(self) -> None:
+        proc = _make_process(stdout="hello\n")
+        with patch("molecules.providers.local_git_adapter.asyncio") as mock_asyncio:
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.subprocess = MagicMock()
+            mock_asyncio.subprocess.PIPE = -1
+            adapter = _adapter()
+            result = await adapter._run("status")
+            assert result == "hello\n"
+
+    @pytest.mark.unit
+    async def test_raises_on_nonzero_exit(self) -> None:
+        proc = _make_process(stderr="fatal: not a git repository", returncode=128)
+        with patch("molecules.providers.local_git_adapter.asyncio") as mock_asyncio:
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.subprocess = MagicMock()
+            mock_asyncio.subprocess.PIPE = -1
+            adapter = _adapter()
+            with pytest.raises(LocalGitError, match="not a git repository"):
+                await adapter._run("status")
+
+    @pytest.mark.unit
+    async def test_raises_ref_not_found_on_128_with_bad_revision(self) -> None:
+        proc = _make_process(stderr="fatal: bad revision 'nonexistent'", returncode=128)
+        with patch("molecules.providers.local_git_adapter.asyncio") as mock_asyncio:
+            mock_asyncio.create_subprocess_exec = AsyncMock(return_value=proc)
+            mock_asyncio.subprocess = MagicMock()
+            mock_asyncio.subprocess.PIPE = -1
+            adapter = _adapter()
+            with pytest.raises(LocalGitRefNotFoundError):
+                await adapter._run("diff", "nonexistent...main")
+
+
+# ---------------------------------------------------------------------------
+# get_diff
+# ---------------------------------------------------------------------------
+
+
+class TestGetDiff:
+    @pytest.mark.unit
+    async def test_simple_modification(self) -> None:
+        """Single file modified, one hunk."""
+        name_status = "M\tsrc/main.py\n"
+        diff_output = (
+            "diff --git a/src/main.py b/src/main.py\n"
+            "index abc..def 100644\n"
+            "--- a/src/main.py\n"
+            "+++ b/src/main.py\n"
+            "@@ -1,3 +1,4 @@\n"
+            " foo\n"
+            "-old\n"
+            "+new\n"
+            "+extra\n"
+        )
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[name_status, diff_output])
+
+        result = await adapter.get_diff("o", "r", "main", "feat")
+
+        assert isinstance(result, DiffData)
+        assert len(result.files) == 1
+        assert result.files[0].path == "src/main.py"
+        assert result.files[0].change_type == "modified"
+        assert result.files[0].additions == 2
+        assert result.files[0].deletions == 1
+        assert result.total_additions == 2
+        assert result.total_deletions == 1
+        assert len(result.files[0].hunks) == 1
+
+    @pytest.mark.unit
+    async def test_multiple_files_mixed_types(self) -> None:
+        """Multiple files: added, modified, deleted."""
+        name_status = "A\tnew.py\nM\texisting.py\nD\told.py\n"
+        diff_output = (
+            "diff --git a/new.py b/new.py\n"
+            "new file mode 100644\n"
+            "--- /dev/null\n"
+            "+++ b/new.py\n"
+            "@@ -0,0 +1,2 @@\n"
+            "+line1\n"
+            "+line2\n"
+            "diff --git a/existing.py b/existing.py\n"
+            "--- a/existing.py\n"
+            "+++ b/existing.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-old\n"
+            "+new\n"
+            "diff --git a/old.py b/old.py\n"
+            "deleted file mode 100644\n"
+            "--- a/old.py\n"
+            "+++ /dev/null\n"
+            "@@ -1,3 +0,0 @@\n"
+            "-a\n"
+            "-b\n"
+            "-c\n"
+        )
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[name_status, diff_output])
+
+        result = await adapter.get_diff("o", "r", "main", "feat")
+
+        assert len(result.files) == 3
+        types = {f.path: f.change_type for f in result.files}
+        assert types["new.py"] == "added"
+        assert types["existing.py"] == "modified"
+        assert types["old.py"] == "deleted"
+        assert result.total_additions == 3  # 2 in new.py + 1 in existing.py
+        assert result.total_deletions == 4  # 1 in existing.py + 3 in old.py
+
+    @pytest.mark.unit
+    async def test_renamed_file(self) -> None:
+        """Renamed file appears with R status."""
+        name_status = "R100\told_name.py\tnew_name.py\n"
+        diff_output = (
+            "diff --git a/old_name.py b/new_name.py\n"
+            "similarity index 100%\n"
+            "rename from old_name.py\n"
+            "rename to new_name.py\n"
+        )
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[name_status, diff_output])
+
+        result = await adapter.get_diff("o", "r", "main", "feat")
+
+        assert len(result.files) == 1
+        assert result.files[0].path == "new_name.py"
+        assert result.files[0].change_type == "renamed"
+
+    @pytest.mark.unit
+    async def test_binary_file(self) -> None:
+        """Binary files produce no hunks."""
+        name_status = "M\timage.png\n"
+        diff_output = "diff --git a/image.png b/image.png\nBinary files a/image.png and b/image.png differ\n"
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[name_status, diff_output])
+
+        result = await adapter.get_diff("o", "r", "main", "feat")
+
+        assert len(result.files) == 1
+        assert result.files[0].path == "image.png"
+        assert result.files[0].hunks == []
+        assert result.files[0].additions == 0
+        assert result.files[0].deletions == 0
+
+    @pytest.mark.unit
+    async def test_empty_diff(self) -> None:
+        """No changes between refs."""
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=["", ""])
+
+        result = await adapter.get_diff("o", "r", "main", "main")
+
+        assert isinstance(result, DiffData)
+        assert result.files == []
+        assert result.total_additions == 0
+        assert result.total_deletions == 0
+
+    @pytest.mark.unit
+    async def test_missing_ref_raises(self) -> None:
+        """Missing ref should raise LocalGitRefNotFoundError."""
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=LocalGitRefNotFoundError("bad revision 'nonexistent'"))
+
+        with pytest.raises(LocalGitRefNotFoundError):
+            await adapter.get_diff("o", "r", "nonexistent", "main")
+
+    @pytest.mark.unit
+    async def test_multiple_hunks_per_file(self) -> None:
+        name_status = "M\tfile.py\n"
+        diff_output = (
+            "diff --git a/file.py b/file.py\n"
+            "--- a/file.py\n"
+            "+++ b/file.py\n"
+            "@@ -1,2 +1,2 @@\n"
+            "-old1\n"
+            "+new1\n"
+            "@@ -10,2 +10,2 @@\n"
+            "-old2\n"
+            "+new2\n"
+        )
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[name_status, diff_output])
+
+        result = await adapter.get_diff("o", "r", "main", "feat")
+
+        assert len(result.files[0].hunks) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_file_tree
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileTree:
+    @pytest.mark.unit
+    async def test_flat_file_list(self) -> None:
+        ls_tree_output = "100644 blob abc1234      150\tREADME.md\n100644 blob def5678       42\tmain.py\n"
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value=ls_tree_output)
+
+        result = await adapter.get_file_tree("o", "r", "HEAD")
+
+        assert isinstance(result, FileTreeNode)
+        assert result.name == "."
+        assert result.type == "dir"
+        assert result.children is not None
+        names = {c.name for c in result.children}
+        assert names == {"README.md", "main.py"}
+
+    @pytest.mark.unit
+    async def test_nested_directories(self) -> None:
+        ls_tree_output = "100644 blob abc1234      100\tsrc/main.py\n100644 blob def5678       50\tsrc/lib/utils.py\n"
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value=ls_tree_output)
+
+        result = await adapter.get_file_tree("o", "r", "HEAD")
+
+        assert result.children is not None
+        src = [c for c in result.children if c.name == "src"][0]
+        assert src.type == "dir"
+        assert src.children is not None
+        child_names = {c.name for c in src.children}
+        assert "main.py" in child_names
+        assert "lib" in child_names
+
+    @pytest.mark.unit
+    async def test_empty_tree(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value="")
+
+        result = await adapter.get_file_tree("o", "r", "HEAD")
+
+        assert result.name == "."
+        assert result.children == []
+
+    @pytest.mark.unit
+    async def test_file_sizes(self) -> None:
+        ls_tree_output = "100644 blob abc1234      999\tbig.dat\n"
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value=ls_tree_output)
+
+        result = await adapter.get_file_tree("o", "r", "HEAD")
+
+        assert result.children is not None
+        assert result.children[0].size == 999
+
+    @pytest.mark.unit
+    async def test_submodules_skipped(self) -> None:
+        """Submodule entries (mode 160000 / type commit) should be skipped."""
+        ls_tree_output = "100644 blob abc1234       42\tREADME.md\n160000 commit def5678        0\tvendor/lib\n"
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value=ls_tree_output)
+
+        result = await adapter.get_file_tree("o", "r", "HEAD")
+
+        assert result.children is not None
+        names = {c.name for c in result.children}
+        assert "README.md" in names
+        assert "vendor" not in names
+
+
+# ---------------------------------------------------------------------------
+# get_file_content
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileContent:
+    @pytest.mark.unit
+    async def test_normal_text_file(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=["42", "print('hello')\nprint('world')\n"])
+
+        result = await adapter.get_file_content("o", "r", "HEAD", "main.py")
+
+        assert isinstance(result, FileContent)
+        assert result.path == "main.py"
+        assert result.content == "print('hello')\nprint('world')\n"
+        assert result.size == 42
+        assert result.language == "python"
+        assert result.lines == 2
+        assert result.truncated is False
+
+    @pytest.mark.unit
+    async def test_large_file_truncated(self) -> None:
+        big_content = "x" * (200 * 1024)  # 200KB
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=[str(len(big_content)), big_content])
+
+        result = await adapter.get_file_content("o", "r", "HEAD", "big.txt")
+
+        assert result.truncated is True
+        assert len(result.content) == 100 * 1024  # 100KB cap
+
+    @pytest.mark.unit
+    async def test_missing_file_raises(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=LocalGitRefNotFoundError("path 'missing.py' does not exist in 'HEAD'"))
+
+        with pytest.raises(LocalGitRefNotFoundError):
+            await adapter.get_file_content("o", "r", "HEAD", "missing.py")
+
+    @pytest.mark.unit
+    async def test_empty_file(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=["0", ""])
+
+        result = await adapter.get_file_content("o", "r", "HEAD", "empty.py")
+
+        assert result.content == ""
+        assert result.size == 0
+        assert result.lines == 0
+
+    @pytest.mark.unit
+    async def test_language_detection(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=["10", "const x = 1;"])
+
+        result = await adapter.get_file_content("o", "r", "HEAD", "app.ts")
+
+        assert result.language == "typescript"
+
+
+# ---------------------------------------------------------------------------
+# get_behind_count
+# ---------------------------------------------------------------------------
+
+
+class TestGetBehindCount:
+    @pytest.mark.unit
+    async def test_normal_count(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value="5\n")
+
+        result = await adapter.get_behind_count("o", "r", "main", "feat")
+
+        assert result == 5
+
+    @pytest.mark.unit
+    async def test_zero_count(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(return_value="0\n")
+
+        result = await adapter.get_behind_count("o", "r", "main", "main")
+
+        assert result == 0
+
+    @pytest.mark.unit
+    async def test_missing_ref_raises(self) -> None:
+        adapter = _adapter()
+        adapter._run = AsyncMock(side_effect=LocalGitRefNotFoundError("bad revision"))
+
+        with pytest.raises(LocalGitRefNotFoundError):
+            await adapter.get_behind_count("o", "r", "nonexistent", "main")

--- a/app/backend/__tests__/molecules/test_project_setup.py
+++ b/app/backend/__tests__/molecules/test_project_setup.py
@@ -1,0 +1,394 @@
+"""Unit tests for ProjectSetupWorkflow.
+
+All tests mock asyncio.create_subprocess_exec to simulate git commands
+and mock ProjectService/WorkspaceService to avoid DB access.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from molecules.workflows.project_setup import (
+    ProjectSetupError,
+    ProjectSetupWorkflow,
+    _detect_provider,
+    _normalize_remote_url,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_process(stdout: str = "", returncode: int = 0) -> AsyncMock:
+    """Create a mock subprocess that returns the given stdout/stderr."""
+    proc = AsyncMock()
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), b""))
+    proc.returncode = returncode
+    return proc
+
+
+def _mock_project(project_id=None, name="test-project"):
+    """Create a mock project object with transition_to."""
+    proj = MagicMock()
+    proj.id = project_id or uuid4()
+    proj.name = name
+    proj.transition_to = MagicMock()
+    return proj
+
+
+def _mock_workspace(workspace_id=None):
+    """Create a mock workspace object."""
+    ws = MagicMock()
+    ws.id = workspace_id or uuid4()
+    return ws
+
+
+# ---------------------------------------------------------------------------
+# Pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectProvider:
+    @pytest.mark.unit
+    def test_github_ssh(self) -> None:
+        assert _detect_provider("git@github.com:owner/repo.git") == "github"
+
+    @pytest.mark.unit
+    def test_github_https(self) -> None:
+        assert _detect_provider("https://github.com/owner/repo") == "github"
+
+    @pytest.mark.unit
+    def test_gitlab(self) -> None:
+        assert _detect_provider("git@gitlab.com:owner/repo.git") == "gitlab"
+
+    @pytest.mark.unit
+    def test_bitbucket(self) -> None:
+        assert _detect_provider("git@bitbucket.org:owner/repo.git") == "bitbucket"
+
+    @pytest.mark.unit
+    def test_unknown(self) -> None:
+        assert _detect_provider("git@selfhosted.example.com:owner/repo.git") == "local"
+
+
+class TestNormalizeRemoteUrl:
+    @pytest.mark.unit
+    def test_ssh_to_https(self) -> None:
+        assert _normalize_remote_url("git@github.com:owner/repo.git") == "https://github.com/owner/repo"
+
+    @pytest.mark.unit
+    def test_https_strips_dot_git(self) -> None:
+        assert _normalize_remote_url("https://github.com/owner/repo.git") == "https://github.com/owner/repo"
+
+    @pytest.mark.unit
+    def test_https_no_dot_git(self) -> None:
+        assert _normalize_remote_url("https://github.com/owner/repo") == "https://github.com/owner/repo"
+
+    @pytest.mark.unit
+    def test_gitlab_ssh(self) -> None:
+        assert _normalize_remote_url("git@gitlab.com:owner/repo.git") == "https://gitlab.com/owner/repo"
+
+
+# ---------------------------------------------------------------------------
+# Workflow tests
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSetupWorkflow:
+    """Tests for ProjectSetupWorkflow.create_local_project."""
+
+    @pytest.mark.unit
+    async def test_happy_path_github_remote(self, tmp_path) -> None:
+        """Valid local_path with GitHub remote creates project + workspace + transitions."""
+        # Set up a fake git repo
+        repo = tmp_path / "my-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        user_id = uuid4()
+        project = _mock_project(name="my-repo")
+        workspace = _mock_workspace()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(return_value=None)
+        workflow.project_service.create = AsyncMock(return_value=project)
+        workflow.workspace_service = MagicMock()
+        workflow.workspace_service.create = AsyncMock(return_value=workspace)
+
+        # Mock git commands: remote returns GitHub URL, symbolic-ref returns "main"
+        remote_proc = _make_process("https://github.com/owner/my-repo.git", returncode=0)
+        branch_proc = _make_process("main", returncode=0)
+
+        with patch(
+            "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=[remote_proc, branch_proc]),
+        ):
+            result = await workflow.create_local_project(
+                user_id=user_id,
+                name="my-repo",
+                local_path=str(repo),
+            )
+
+        # Verify result
+        assert result.project_id == project.id
+        assert result.workspace_id == workspace.id
+        assert result.project_name == "my-repo"
+
+        # Verify project creation
+        create_call = workflow.project_service.create.call_args
+        project_data = create_call[0][1]
+        assert project_data.github_repo == "https://github.com/owner/my-repo"
+        assert project_data.owner_id == user_id
+        assert project_data.local_path == str(repo)
+
+        # Verify workspace creation
+        ws_call = workflow.workspace_service.create.call_args
+        ws_data = ws_call[0][1]
+        assert ws_data.provider == "github"
+        assert ws_data.repo_url == "https://github.com/owner/my-repo"
+        assert ws_data.default_branch == "main"
+        assert ws_data.local_path == str(repo)
+
+        # Verify transition
+        project.transition_to.assert_called_once_with("active")
+        db.flush.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_no_remote_uses_synthetic_url(self, tmp_path) -> None:
+        """Local path with no remote uses synthetic github_repo URL, provider=local."""
+        repo = tmp_path / "local-only"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        user_id = uuid4()
+        project = _mock_project(name="local-only")
+        workspace = _mock_workspace()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(return_value=None)
+        workflow.project_service.create = AsyncMock(return_value=project)
+        workflow.workspace_service = MagicMock()
+        workflow.workspace_service.create = AsyncMock(return_value=workspace)
+
+        # remote fails (no origin), branch succeeds
+        remote_proc = _make_process("", returncode=128)
+        branch_proc = _make_process("develop", returncode=0)
+
+        with patch(
+            "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=[remote_proc, branch_proc]),
+        ):
+            result = await workflow.create_local_project(
+                user_id=user_id,
+                name="local-only",
+                local_path=str(repo),
+            )
+
+        assert result.project_name == "local-only"
+
+        # Verify synthetic github_repo
+        project_data = workflow.project_service.create.call_args[0][1]
+        assert project_data.github_repo == "https://github.com/local/local-only"
+
+        # Verify workspace uses local provider
+        ws_data = workflow.workspace_service.create.call_args[0][1]
+        assert ws_data.provider == "local"
+        assert ws_data.repo_url == "https://github.com/local/local-only"
+        assert ws_data.default_branch == "develop"
+
+    @pytest.mark.unit
+    async def test_gitlab_remote_uses_synthetic_github_repo(self, tmp_path) -> None:
+        """GitLab remote uses synthetic github_repo (to pass schema validator) but real repo_url."""
+        repo = tmp_path / "gl-project"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        user_id = uuid4()
+        project = _mock_project(name="gl-project")
+        workspace = _mock_workspace()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(return_value=None)
+        workflow.project_service.create = AsyncMock(return_value=project)
+        workflow.workspace_service = MagicMock()
+        workflow.workspace_service.create = AsyncMock(return_value=workspace)
+
+        remote_proc = _make_process("git@gitlab.com:owner/gl-project.git", returncode=0)
+        branch_proc = _make_process("main", returncode=0)
+
+        with patch(
+            "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=[remote_proc, branch_proc]),
+        ):
+            result = await workflow.create_local_project(
+                user_id=user_id,
+                name="gl-project",
+                local_path=str(repo),
+            )
+
+        assert result.project_name == "gl-project"
+
+        # github_repo must pass the "github.com" validator — synthetic URL
+        project_data = workflow.project_service.create.call_args[0][1]
+        assert "github.com" in project_data.github_repo
+        assert project_data.github_repo == "https://github.com/local/gl-project"
+
+        # workspace repo_url should be the real GitLab URL
+        ws_data = workflow.workspace_service.create.call_args[0][1]
+        assert ws_data.repo_url == "https://gitlab.com/owner/gl-project"
+        assert ws_data.provider == "gitlab"
+
+    @pytest.mark.unit
+    async def test_nonexistent_path_raises(self) -> None:
+        """Path that does not exist raises ProjectSetupError."""
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+
+        with pytest.raises(ProjectSetupError, match="Directory does not exist"):
+            await workflow.create_local_project(
+                user_id=uuid4(),
+                name="nope",
+                local_path="/nonexistent/path/that/does/not/exist",
+            )
+
+    @pytest.mark.unit
+    async def test_not_a_git_repo_raises(self, tmp_path) -> None:
+        """Path that exists but has no .git directory raises ProjectSetupError."""
+        not_git = tmp_path / "not-a-repo"
+        not_git.mkdir()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+
+        with pytest.raises(ProjectSetupError, match="Not a git repository"):
+            await workflow.create_local_project(
+                user_id=uuid4(),
+                name="not-a-repo",
+                local_path=str(not_git),
+            )
+
+    @pytest.mark.unit
+    async def test_path_is_file_raises(self, tmp_path) -> None:
+        """Path that is a file (not a directory) raises ProjectSetupError."""
+        file_path = tmp_path / "some-file.txt"
+        file_path.write_text("hello")
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+
+        with pytest.raises(ProjectSetupError, match="Path is not a directory"):
+            await workflow.create_local_project(
+                user_id=uuid4(),
+                name="oops",
+                local_path=str(file_path),
+            )
+
+    @pytest.mark.unit
+    async def test_duplicate_name_raises(self, tmp_path) -> None:
+        """Duplicate project name raises ProjectSetupError."""
+        repo = tmp_path / "dup-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(
+            return_value=MagicMock()  # existing project found
+        )
+
+        remote_proc = _make_process("https://github.com/owner/dup-repo", returncode=0)
+        branch_proc = _make_process("main", returncode=0)
+
+        with (
+            patch(
+                "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+                AsyncMock(side_effect=[remote_proc, branch_proc]),
+            ),
+            pytest.raises(ProjectSetupError, match="already exists"),
+        ):
+            await workflow.create_local_project(
+                user_id=uuid4(),
+                name="dup-repo",
+                local_path=str(repo),
+            )
+
+    @pytest.mark.unit
+    async def test_branch_fallback_to_main(self, tmp_path) -> None:
+        """When symbolic-ref fails, default branch falls back to 'main'."""
+        repo = tmp_path / "detached-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        user_id = uuid4()
+        project = _mock_project(name="detached-repo")
+        workspace = _mock_workspace()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(return_value=None)
+        workflow.project_service.create = AsyncMock(return_value=project)
+        workflow.workspace_service = MagicMock()
+        workflow.workspace_service.create = AsyncMock(return_value=workspace)
+
+        # remote succeeds, but branch fails (detached HEAD)
+        remote_proc = _make_process("https://github.com/owner/detached-repo", returncode=0)
+        branch_proc = _make_process("", returncode=128)
+
+        with patch(
+            "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=[remote_proc, branch_proc]),
+        ):
+            await workflow.create_local_project(
+                user_id=user_id,
+                name="detached-repo",
+                local_path=str(repo),
+            )
+
+        ws_data = workflow.workspace_service.create.call_args[0][1]
+        assert ws_data.default_branch == "main"
+
+    @pytest.mark.unit
+    async def test_custom_description(self, tmp_path) -> None:
+        """Custom description is passed through to the project."""
+        repo = tmp_path / "desc-repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+
+        project = _mock_project(name="desc-repo")
+        workspace = _mock_workspace()
+
+        db = AsyncMock()
+        workflow = ProjectSetupWorkflow(db=db)
+        workflow.project_service = MagicMock()
+        workflow.project_service.get_by_name = AsyncMock(return_value=None)
+        workflow.project_service.create = AsyncMock(return_value=project)
+        workflow.workspace_service = MagicMock()
+        workflow.workspace_service.create = AsyncMock(return_value=workspace)
+
+        remote_proc = _make_process("https://github.com/owner/desc-repo", returncode=0)
+        branch_proc = _make_process("main", returncode=0)
+
+        with patch(
+            "molecules.workflows.project_setup.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=[remote_proc, branch_proc]),
+        ):
+            await workflow.create_local_project(
+                user_id=uuid4(),
+                name="desc-repo",
+                local_path=str(repo),
+                description="My custom description",
+            )
+
+        project_data = workflow.project_service.create.call_args[0][1]
+        assert project_data.description == "My custom description"

--- a/app/backend/__tests__/molecules/test_stack_api_reader.py
+++ b/app/backend/__tests__/molecules/test_stack_api_reader.py
@@ -1,0 +1,126 @@
+"""Tests for StackAPI._get_reader_for_branch adapter resolution logic.
+
+Verifies that the correct git adapter (LocalGitAdapter vs GitHubAdapter)
+is selected based on workspace configuration.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import pytest
+
+from molecules.providers.local_git_adapter import LocalGitAdapter
+
+
+class TestGetReaderForBranch:
+    """Test StackAPI._get_reader_for_branch resolution."""
+
+    def _make_branch(self, workspace_id: str | None = None) -> MagicMock:
+        branch = MagicMock()
+        branch.id = uuid4()
+        branch.workspace_id = workspace_id or uuid4()
+        branch.stack_id = uuid4()
+        return branch
+
+    def _make_workspace(self, local_path: str | None = None, repo_url: str = "https://github.com/o/r") -> MagicMock:
+        ws = MagicMock()
+        ws.id = uuid4()
+        ws.local_path = local_path
+        ws.repo_url = repo_url
+        return ws
+
+    def _make_stack_api(
+        self, github: MagicMock | None = None, workspace: MagicMock | None = None, branch: MagicMock | None = None
+    ) -> MagicMock:
+        """Create a StackAPI-like object with mocked dependencies."""
+        from molecules.apis.stack_api import StackAPI
+
+        db = AsyncMock()
+        api = StackAPI.__new__(StackAPI)
+        api.db = db
+        api.github = github
+        api.entity = MagicMock()
+        api.entity.get_branch = AsyncMock(return_value=branch or self._make_branch())
+        api.entity.workspace_service = MagicMock()
+        api.entity.workspace_service.get = AsyncMock(return_value=workspace)
+        api._comment_svc = MagicMock()
+        return api
+
+    @pytest.mark.unit
+    async def test_local_path_exists_returns_local_adapter(self, tmp_path: Path) -> None:
+        """Workspace with valid local_path returns LocalGitAdapter."""
+        # Create a .git directory to make it look like a real repo
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        workspace = self._make_workspace(local_path=str(tmp_path))
+        branch = self._make_branch(workspace_id=workspace.id)
+        api = self._make_stack_api(workspace=workspace, branch=branch)
+
+        reader = await api._get_reader_for_branch(branch.id)
+
+        assert isinstance(reader, LocalGitAdapter)
+        assert reader.repo_path == str(tmp_path)
+
+    @pytest.mark.unit
+    async def test_local_path_not_git_repo_falls_back_to_github(self, tmp_path: Path) -> None:
+        """Workspace with local_path but no .git dir falls back to GitHub."""
+        github = MagicMock()
+        workspace = self._make_workspace(local_path=str(tmp_path))
+        branch = self._make_branch(workspace_id=workspace.id)
+        api = self._make_stack_api(github=github, workspace=workspace, branch=branch)
+
+        reader = await api._get_reader_for_branch(branch.id)
+
+        assert reader is github
+
+    @pytest.mark.unit
+    async def test_no_local_path_uses_github(self) -> None:
+        """Workspace without local_path uses GitHub adapter."""
+        github = MagicMock()
+        workspace = self._make_workspace(local_path=None)
+        branch = self._make_branch(workspace_id=workspace.id)
+        api = self._make_stack_api(github=github, workspace=workspace, branch=branch)
+
+        reader = await api._get_reader_for_branch(branch.id)
+
+        assert reader is github
+
+    @pytest.mark.unit
+    async def test_no_local_path_no_github_raises(self) -> None:
+        """Workspace without local_path and no GitHub adapter raises RuntimeError."""
+        workspace = self._make_workspace(local_path=None)
+        branch = self._make_branch(workspace_id=workspace.id)
+        api = self._make_stack_api(github=None, workspace=workspace, branch=branch)
+
+        with pytest.raises(RuntimeError, match="No git reader available"):
+            await api._get_reader_for_branch(branch.id)
+
+    @pytest.mark.unit
+    async def test_local_path_nonexistent_dir_falls_back(self) -> None:
+        """Workspace with local_path that doesn't exist falls back to GitHub."""
+        github = MagicMock()
+        workspace = self._make_workspace(local_path="/nonexistent/path")
+        branch = self._make_branch(workspace_id=workspace.id)
+        api = self._make_stack_api(github=github, workspace=workspace, branch=branch)
+
+        reader = await api._get_reader_for_branch(branch.id)
+
+        assert reader is github
+
+    @pytest.mark.unit
+    async def test_missing_workspace_raises(self) -> None:
+        """Missing workspace raises BranchNotFoundError."""
+        from molecules.exceptions import BranchNotFoundError
+
+        branch = self._make_branch()
+        api = self._make_stack_api(workspace=None, branch=branch)
+
+        with pytest.raises(BranchNotFoundError):
+            await api._get_reader_for_branch(branch.id)

--- a/app/backend/src/features/projects/schemas/output.py
+++ b/app/backend/src/features/projects/schemas/output.py
@@ -10,7 +10,7 @@ class ProjectResponse(BaseModel):
     reference_number: str | None = None
     name: str
     description: str | None = None
-    metadata_: dict[str, Any]
+    metadata_: dict[str, Any] | None = None
     state: str
     created_at: datetime
     updated_at: datetime

--- a/app/backend/src/features/workspaces/models.py
+++ b/app/backend/src/features/workspaces/models.py
@@ -33,7 +33,7 @@ class Workspace(EventPattern):
     project_id = Field(UUID, foreign_key="projects.id", required=True, index=True)
     name = Field(str, required=True, max_length=200)
     repo_url = Field(str, required=True, max_length=500)
-    provider = Field(str, required=True, max_length=20, choices=["github", "gitlab", "bitbucket"])
+    provider = Field(str, required=True, max_length=20, choices=["github", "gitlab", "bitbucket", "local"])
     default_branch = Field(str, required=True, max_length=200, default="main")
     local_path = Field(str, nullable=True, max_length=500)
     metadata_ = Field(dict, default=dict)

--- a/app/backend/src/features/workspaces/schemas/input.py
+++ b/app/backend/src/features/workspaces/schemas/input.py
@@ -9,7 +9,7 @@ class WorkspaceCreate(BaseModel):
     project_id: UUID
     name: str = PydanticField(..., min_length=1, max_length=200)
     repo_url: str = PydanticField(..., min_length=1, max_length=500)
-    provider: Literal["github", "gitlab", "bitbucket"]
+    provider: Literal["github", "gitlab", "bitbucket", "local"]
     default_branch: str = PydanticField("main", min_length=1, max_length=200)
     local_path: str | None = None
     metadata_: dict[str, Any] | None = None
@@ -22,7 +22,7 @@ class WorkspaceCreate(BaseModel):
 class WorkspaceUpdate(BaseModel):
     name: str | None = PydanticField(None, min_length=1, max_length=200)
     repo_url: str | None = PydanticField(None, min_length=1, max_length=500)
-    provider: Literal["github", "gitlab", "bitbucket"] | None = None
+    provider: Literal["github", "gitlab", "bitbucket", "local"] | None = None
     default_branch: str | None = PydanticField(None, min_length=1, max_length=200)
     local_path: str | None = None
     metadata_: dict[str, Any] | None = None

--- a/app/backend/src/molecules/apis/stack_api.py
+++ b/app/backend/src/molecules/apis/stack_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from features.branches.schemas.output import BranchResponse
@@ -19,6 +20,7 @@ from molecules.events import (
     DomainEvent,
     publish,
 )
+from molecules.exceptions import BranchNotFoundError
 from molecules.providers.github_adapter import parse_owner_repo
 
 if TYPE_CHECKING:
@@ -27,6 +29,7 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from features.review_comments.schemas.input import ReviewCommentCreate, ReviewCommentUpdate
+    from molecules.providers.git_types import GitRepoProtocol
     from molecules.providers.github_adapter import DiffData, FileContent, FileTreeNode, GitHubAdapter
 
 
@@ -303,31 +306,53 @@ class StackAPI:
 
         return result
 
-    # --- Git data (read-through via GitHubAdapter) ---
+    # --- Git reader resolution ---
+
+    async def _get_reader_for_branch(self, branch_id: UUID) -> GitRepoProtocol:
+        """Return the best available git reader for a branch.
+
+        Prefers LocalGitAdapter when the workspace has a valid local_path
+        with a .git directory. Falls back to the GitHubAdapter otherwise.
+        Raises RuntimeError if neither is available.
+        """
+        from molecules.providers.local_git_adapter import LocalGitAdapter
+
+        branch = await self.entity.get_branch(branch_id)
+        workspace = await self.entity.workspace_service.get(self.db, branch.workspace_id)
+        if workspace is None:
+            raise BranchNotFoundError(branch_id)
+
+        # Prefer local clone when available
+        local_path = getattr(workspace, "local_path", None)
+        if local_path and Path(local_path).is_dir() and (Path(local_path) / ".git").exists():
+            return LocalGitAdapter(local_path)
+
+        # Fall back to GitHub adapter
+        if self.github is not None:
+            return self.github
+
+        msg = "No git reader available for branch (no local clone and no GitHub adapter)"
+        raise RuntimeError(msg)
+
+    # --- Git data (read-through via git adapter) ---
 
     async def get_branch_diff(self, stack_id: UUID, branch_id: UUID) -> DiffData:
         """Get diff for a branch relative to its base."""
-        if self.github is None:
-            msg = "GitHubAdapter not configured"
-            raise RuntimeError(msg)
+        reader = await self._get_reader_for_branch(branch_id)
         owner, repo, base_ref, head_ref = await self.entity.get_branch_repo_context(branch_id)
-        return await self.github.get_diff(owner, repo, base_ref, head_ref)
+        return await reader.get_diff(owner, repo, base_ref, head_ref)
 
     async def get_branch_tree(self, stack_id: UUID, branch_id: UUID) -> FileTreeNode:
         """Get file tree at branch head."""
-        if self.github is None:
-            msg = "GitHubAdapter not configured"
-            raise RuntimeError(msg)
+        reader = await self._get_reader_for_branch(branch_id)
         owner, repo, _, head_ref = await self.entity.get_branch_repo_context(branch_id)
-        return await self.github.get_file_tree(owner, repo, head_ref)
+        return await reader.get_file_tree(owner, repo, head_ref)
 
     async def get_branch_file(self, stack_id: UUID, branch_id: UUID, path: str) -> FileContent:
         """Get file content at branch head."""
-        if self.github is None:
-            msg = "GitHubAdapter not configured"
-            raise RuntimeError(msg)
+        reader = await self._get_reader_for_branch(branch_id)
         owner, repo, _, head_ref = await self.entity.get_branch_repo_context(branch_id)
-        return await self.github.get_file_content(owner, repo, head_ref, path)
+        return await reader.get_file_content(owner, repo, head_ref, path)
 
     async def merge_stack(self, stack_id: UUID) -> dict[str, object]:
         """Merge all PRs in the stack, bottom-up."""

--- a/app/backend/src/molecules/providers/git_types.py
+++ b/app/backend/src/molecules/providers/git_types.py
@@ -1,0 +1,250 @@
+"""Shared types, DTOs, and parsing utilities for git adapters.
+
+These are protocol-level types used by both GitHubAdapter and LocalGitAdapter.
+Extracted from github_adapter.py for reuse without coupling to a specific adapter.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import Protocol
+
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Protocol DTOs
+# ---------------------------------------------------------------------------
+
+
+class DiffLine(BaseModel):
+    type: str  # "context" | "add" | "del" | "hunk"
+    old_num: int | None = None
+    new_num: int | None = None
+    content: str
+
+
+class DiffHunk(BaseModel):
+    header: str
+    lines: list[DiffLine]
+
+
+class DiffFile(BaseModel):
+    path: str
+    change_type: str  # "added" | "modified" | "deleted" | "renamed"
+    additions: int
+    deletions: int
+    hunks: list[DiffHunk]
+
+
+class DiffData(BaseModel):
+    files: list[DiffFile]
+    total_additions: int
+    total_deletions: int
+
+
+class FileTreeNode(BaseModel):
+    name: str
+    path: str
+    type: str  # "file" | "dir"
+    children: list[FileTreeNode] | None = None
+    size: int | None = None
+
+
+class FileContent(BaseModel):
+    path: str
+    content: str
+    size: int
+    language: str | None = None
+    lines: int
+    truncated: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+class GitRepoProtocol(Protocol):
+    """Read-only access to git repository data."""
+
+    async def get_diff(self, owner: str, repo: str, base_ref: str, head_ref: str) -> DiffData: ...
+
+    async def get_file_tree(self, owner: str, repo: str, ref: str) -> FileTreeNode: ...
+
+    async def get_file_content(self, owner: str, repo: str, ref: str, path: str) -> FileContent: ...
+
+    async def get_behind_count(self, owner: str, repo: str, base_ref: str, head_ref: str) -> int: ...
+
+
+# ---------------------------------------------------------------------------
+# Language detection from file extension
+# ---------------------------------------------------------------------------
+
+_EXTENSION_LANGUAGE_MAP: dict[str, str] = {
+    ".py": "python",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".go": "go",
+    ".rs": "rust",
+    ".rb": "ruby",
+    ".java": "java",
+    ".kt": "kotlin",
+    ".swift": "swift",
+    ".c": "c",
+    ".cpp": "cpp",
+    ".h": "c",
+    ".hpp": "cpp",
+    ".cs": "csharp",
+    ".css": "css",
+    ".scss": "scss",
+    ".html": "html",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".toml": "toml",
+    ".md": "markdown",
+    ".sql": "sql",
+    ".sh": "shell",
+    ".bash": "shell",
+    ".zsh": "shell",
+    ".dockerfile": "dockerfile",
+    ".xml": "xml",
+    ".graphql": "graphql",
+    ".proto": "protobuf",
+    ".vue": "vue",
+    ".svelte": "svelte",
+}
+
+
+def _detect_language(path: str) -> str | None:
+    """Detect language from file extension."""
+    name = PurePosixPath(path).name.lower()
+    if name == "dockerfile":
+        return "dockerfile"
+    if name in ("makefile", "justfile"):
+        return "makefile"
+    suffix = PurePosixPath(path).suffix.lower()
+    return _EXTENSION_LANGUAGE_MAP.get(suffix)
+
+
+_MAX_CONTENT_SIZE = 100 * 1024  # 100KB
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing utilities
+# ---------------------------------------------------------------------------
+
+# Matches the hunk header: @@ -old_start[,old_count] +new_start[,new_count] @@ optional text
+_HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$")
+
+
+def _parse_patch(patch: str) -> list[DiffHunk]:
+    """Parse a unified-diff patch string into DiffHunk objects."""
+    hunks: list[DiffHunk] = []
+    current_hunk: DiffHunk | None = None
+    old_num = 0
+    new_num = 0
+
+    for raw_line in patch.split("\n"):
+        hunk_match = _HUNK_HEADER_RE.match(raw_line)
+        if hunk_match:
+            old_num = int(hunk_match.group(1))
+            new_num = int(hunk_match.group(2))
+            current_hunk = DiffHunk(header=raw_line, lines=[])
+            hunks.append(current_hunk)
+            current_hunk.lines.append(DiffLine(type="hunk", old_num=None, new_num=None, content=raw_line))
+            continue
+
+        if current_hunk is None:
+            continue
+
+        if raw_line.startswith("+"):
+            current_hunk.lines.append(DiffLine(type="add", old_num=None, new_num=new_num, content=raw_line[1:]))
+            new_num += 1
+        elif raw_line.startswith("-"):
+            current_hunk.lines.append(DiffLine(type="del", old_num=old_num, new_num=None, content=raw_line[1:]))
+            old_num += 1
+        else:
+            # Context line (starts with space or is empty)
+            content = raw_line[1:] if raw_line.startswith(" ") else raw_line
+            current_hunk.lines.append(DiffLine(type="context", old_num=old_num, new_num=new_num, content=content))
+            old_num += 1
+            new_num += 1
+
+    return hunks
+
+
+def _build_file_tree(entries: list[dict[str, object]]) -> FileTreeNode:
+    """Build a recursive FileTreeNode from a flat tree array.
+
+    Works with both GitHub API entries (with explicit tree/blob types)
+    and local git ls-tree output (blobs only, directories implied).
+    """
+    root = FileTreeNode(name=".", path="", type="dir", children=[])
+    # Map path -> node for quick parent lookup
+    dir_map: dict[str, FileTreeNode] = {"": root}
+
+    # Sort entries so directories come first and paths are alphabetical
+    sorted_entries = sorted(entries, key=lambda e: str(e.get("path", "")))
+
+    for entry in sorted_entries:
+        path = str(entry.get("path", ""))
+        entry_type = str(entry.get("type", ""))
+        size = entry.get("size")
+
+        parts = path.split("/")
+        name = parts[-1]
+
+        # Ensure all parent directories exist
+        for i in range(1, len(parts)):
+            dir_path = "/".join(parts[:i])
+            if dir_path not in dir_map:
+                dir_name = parts[i - 1]
+                dir_node = FileTreeNode(name=dir_name, path=dir_path, type="dir", children=[])
+                parent_path = "/".join(parts[: i - 1]) if i > 1 else ""
+                parent = dir_map.get(parent_path, root)
+                if parent.children is None:
+                    parent.children = []
+                parent.children.append(dir_node)
+                dir_map[dir_path] = dir_node
+
+        if entry_type == "tree":
+            # Directory entry from GitHub
+            if path not in dir_map:
+                node = FileTreeNode(name=name, path=path, type="dir", children=[])
+                parent_path = "/".join(parts[:-1])
+                parent = dir_map.get(parent_path, root)
+                if parent.children is None:
+                    parent.children = []
+                parent.children.append(node)
+                dir_map[path] = node
+        elif entry_type == "blob":
+            # File entry
+            node = FileTreeNode(
+                name=name,
+                path=path,
+                type="file",
+                children=None,
+                size=int(str(size)) if size is not None else None,
+            )
+            parent_path = "/".join(parts[:-1])
+            parent = dir_map.get(parent_path, root)
+            if parent.children is None:
+                parent.children = []
+            parent.children.append(node)
+
+    return root
+
+
+# Map GitHub status values to our change_type
+_STATUS_MAP: dict[str, str] = {
+    "added": "added",
+    "modified": "modified",
+    "removed": "deleted",
+    "renamed": "renamed",
+    "changed": "modified",
+    "copied": "added",
+}

--- a/app/backend/src/molecules/providers/github_adapter.py
+++ b/app/backend/src/molecules/providers/github_adapter.py
@@ -1,78 +1,24 @@
 from __future__ import annotations
 
 import base64
-import re
-from pathlib import PurePosixPath
-from typing import Protocol
 
 import httpx
 from pattern_stack.atoms.cache import get_cache
-from pydantic import BaseModel
 
-# ---------------------------------------------------------------------------
-# Protocol DTOs
-# ---------------------------------------------------------------------------
-
-
-class DiffLine(BaseModel):
-    type: str  # "context" | "add" | "del" | "hunk"
-    old_num: int | None = None
-    new_num: int | None = None
-    content: str
-
-
-class DiffHunk(BaseModel):
-    header: str
-    lines: list[DiffLine]
-
-
-class DiffFile(BaseModel):
-    path: str
-    change_type: str  # "added" | "modified" | "deleted" | "renamed"
-    additions: int
-    deletions: int
-    hunks: list[DiffHunk]
-
-
-class DiffData(BaseModel):
-    files: list[DiffFile]
-    total_additions: int
-    total_deletions: int
-
-
-class FileTreeNode(BaseModel):
-    name: str
-    path: str
-    type: str  # "file" | "dir"
-    children: list[FileTreeNode] | None = None
-    size: int | None = None
-
-
-class FileContent(BaseModel):
-    path: str
-    content: str
-    size: int
-    language: str | None = None
-    lines: int
-    truncated: bool = False
-
-
-# ---------------------------------------------------------------------------
-# Protocol
-# ---------------------------------------------------------------------------
-
-
-class GitRepoProtocol(Protocol):
-    """Read-only access to git repository data."""
-
-    async def get_diff(self, owner: str, repo: str, base_ref: str, head_ref: str) -> DiffData: ...
-
-    async def get_file_tree(self, owner: str, repo: str, ref: str) -> FileTreeNode: ...
-
-    async def get_file_content(self, owner: str, repo: str, ref: str, path: str) -> FileContent: ...
-
-    async def get_behind_count(self, owner: str, repo: str, base_ref: str, head_ref: str) -> int: ...
-
+# Re-export shared types from git_types so existing imports keep working.
+# The ``as`` aliases tell mypy these are explicit re-exports (strict mode).
+from molecules.providers.git_types import _MAX_CONTENT_SIZE as _MAX_CONTENT_SIZE
+from molecules.providers.git_types import _STATUS_MAP as _STATUS_MAP
+from molecules.providers.git_types import DiffData as DiffData
+from molecules.providers.git_types import DiffFile as DiffFile
+from molecules.providers.git_types import DiffHunk as DiffHunk
+from molecules.providers.git_types import DiffLine as DiffLine
+from molecules.providers.git_types import FileContent as FileContent
+from molecules.providers.git_types import FileTreeNode as FileTreeNode
+from molecules.providers.git_types import GitRepoProtocol as GitRepoProtocol
+from molecules.providers.git_types import _build_file_tree as _build_file_tree
+from molecules.providers.git_types import _detect_language as _detect_language
+from molecules.providers.git_types import _parse_patch as _parse_patch
 
 # ---------------------------------------------------------------------------
 # Exceptions
@@ -97,175 +43,8 @@ class GitHubRateLimitError(GitHubAPIError):
         super().__init__(403, "GitHub API rate limit exceeded")
 
 
-# ---------------------------------------------------------------------------
-# Language detection from file extension
-# ---------------------------------------------------------------------------
-
-_EXTENSION_LANGUAGE_MAP: dict[str, str] = {
-    ".py": "python",
-    ".ts": "typescript",
-    ".tsx": "typescript",
-    ".js": "javascript",
-    ".jsx": "javascript",
-    ".go": "go",
-    ".rs": "rust",
-    ".rb": "ruby",
-    ".java": "java",
-    ".kt": "kotlin",
-    ".swift": "swift",
-    ".c": "c",
-    ".cpp": "cpp",
-    ".h": "c",
-    ".hpp": "cpp",
-    ".cs": "csharp",
-    ".css": "css",
-    ".scss": "scss",
-    ".html": "html",
-    ".json": "json",
-    ".yaml": "yaml",
-    ".yml": "yaml",
-    ".toml": "toml",
-    ".md": "markdown",
-    ".sql": "sql",
-    ".sh": "shell",
-    ".bash": "shell",
-    ".zsh": "shell",
-    ".dockerfile": "dockerfile",
-    ".xml": "xml",
-    ".graphql": "graphql",
-    ".proto": "protobuf",
-    ".vue": "vue",
-    ".svelte": "svelte",
-}
-
-
-def _detect_language(path: str) -> str | None:
-    """Detect language from file extension."""
-    name = PurePosixPath(path).name.lower()
-    if name == "dockerfile":
-        return "dockerfile"
-    if name in ("makefile", "justfile"):
-        return "makefile"
-    suffix = PurePosixPath(path).suffix.lower()
-    return _EXTENSION_LANGUAGE_MAP.get(suffix)
-
-
-_MAX_CONTENT_SIZE = 100 * 1024  # 100KB
 _CACHE_NS = "github"
 _CACHE_TTL = 3600  # 1 hour — git SHAs are content-addressed, safe to cache long
-
-
-# ---------------------------------------------------------------------------
-# Diff parsing utilities
-# ---------------------------------------------------------------------------
-
-# Matches the hunk header: @@ -old_start[,old_count] +new_start[,new_count] @@ optional text
-_HUNK_HEADER_RE = re.compile(r"^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$")
-
-
-def _parse_patch(patch: str) -> list[DiffHunk]:
-    """Parse a unified-diff patch string into DiffHunk objects."""
-    hunks: list[DiffHunk] = []
-    current_hunk: DiffHunk | None = None
-    old_num = 0
-    new_num = 0
-
-    for raw_line in patch.split("\n"):
-        hunk_match = _HUNK_HEADER_RE.match(raw_line)
-        if hunk_match:
-            old_num = int(hunk_match.group(1))
-            new_num = int(hunk_match.group(2))
-            current_hunk = DiffHunk(header=raw_line, lines=[])
-            hunks.append(current_hunk)
-            current_hunk.lines.append(DiffLine(type="hunk", old_num=None, new_num=None, content=raw_line))
-            continue
-
-        if current_hunk is None:
-            continue
-
-        if raw_line.startswith("+"):
-            current_hunk.lines.append(DiffLine(type="add", old_num=None, new_num=new_num, content=raw_line[1:]))
-            new_num += 1
-        elif raw_line.startswith("-"):
-            current_hunk.lines.append(DiffLine(type="del", old_num=old_num, new_num=None, content=raw_line[1:]))
-            old_num += 1
-        else:
-            # Context line (starts with space or is empty)
-            content = raw_line[1:] if raw_line.startswith(" ") else raw_line
-            current_hunk.lines.append(DiffLine(type="context", old_num=old_num, new_num=new_num, content=content))
-            old_num += 1
-            new_num += 1
-
-    return hunks
-
-
-def _build_file_tree(entries: list[dict[str, object]]) -> FileTreeNode:
-    """Build a recursive FileTreeNode from GitHub's flat tree array."""
-    root = FileTreeNode(name=".", path="", type="dir", children=[])
-    # Map path -> node for quick parent lookup
-    dir_map: dict[str, FileTreeNode] = {"": root}
-
-    # Sort entries so directories come first and paths are alphabetical
-    sorted_entries = sorted(entries, key=lambda e: str(e.get("path", "")))
-
-    for entry in sorted_entries:
-        path = str(entry.get("path", ""))
-        entry_type = str(entry.get("type", ""))
-        size = entry.get("size")
-
-        parts = path.split("/")
-        name = parts[-1]
-
-        # Ensure all parent directories exist
-        for i in range(1, len(parts)):
-            dir_path = "/".join(parts[:i])
-            if dir_path not in dir_map:
-                dir_name = parts[i - 1]
-                dir_node = FileTreeNode(name=dir_name, path=dir_path, type="dir", children=[])
-                parent_path = "/".join(parts[: i - 1]) if i > 1 else ""
-                parent = dir_map.get(parent_path, root)
-                if parent.children is None:
-                    parent.children = []
-                parent.children.append(dir_node)
-                dir_map[dir_path] = dir_node
-
-        if entry_type == "tree":
-            # Directory entry from GitHub
-            if path not in dir_map:
-                node = FileTreeNode(name=name, path=path, type="dir", children=[])
-                parent_path = "/".join(parts[:-1])
-                parent = dir_map.get(parent_path, root)
-                if parent.children is None:
-                    parent.children = []
-                parent.children.append(node)
-                dir_map[path] = node
-        elif entry_type == "blob":
-            # File entry
-            node = FileTreeNode(
-                name=name,
-                path=path,
-                type="file",
-                children=None,
-                size=int(str(size)) if size is not None else None,
-            )
-            parent_path = "/".join(parts[:-1])
-            parent = dir_map.get(parent_path, root)
-            if parent.children is None:
-                parent.children = []
-            parent.children.append(node)
-
-    return root
-
-
-# Map GitHub status values to our change_type
-_STATUS_MAP: dict[str, str] = {
-    "added": "added",
-    "modified": "modified",
-    "removed": "deleted",
-    "renamed": "renamed",
-    "changed": "modified",
-    "copied": "added",
-}
 
 
 # ---------------------------------------------------------------------------

--- a/app/backend/src/molecules/providers/local_git_adapter.py
+++ b/app/backend/src/molecules/providers/local_git_adapter.py
@@ -1,0 +1,271 @@
+"""LocalGitAdapter — read diffs, trees, and files from local git clones.
+
+Implements GitRepoProtocol by running git commands against a local clone
+on disk, so stack-bench can serve diffs, file trees, and file content for
+workspaces that have a local_path without needing a GitHub token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+from molecules.providers.git_types import (
+    _MAX_CONTENT_SIZE,
+    DiffData,
+    DiffFile,
+    FileContent,
+    FileTreeNode,
+    _build_file_tree,
+    _detect_language,
+    _parse_patch,
+)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class LocalGitError(Exception):
+    """Base error for local git operations."""
+
+    def __init__(self, message: str, returncode: int = 1) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+
+
+class LocalGitRefNotFoundError(LocalGitError):
+    """A requested ref (branch, SHA) does not exist in the local repo."""
+
+
+# ---------------------------------------------------------------------------
+# Status code mapping (git --name-status letters to our change_type)
+# ---------------------------------------------------------------------------
+
+_NAME_STATUS_MAP: dict[str, str] = {
+    "A": "added",
+    "M": "modified",
+    "D": "deleted",
+    "T": "modified",  # type change
+    "C": "added",  # copied
+}
+
+# Regex to split full `git diff` output by file boundary
+_DIFF_FILE_RE = re.compile(r"^diff --git a/.+ b/(.+)$", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# LocalGitAdapter
+# ---------------------------------------------------------------------------
+
+
+class LocalGitAdapter:
+    """Implements GitRepoProtocol using local git subprocess calls.
+
+    The owner/repo parameters required by the protocol are accepted but
+    ignored -- the adapter uses repo_path from __init__ instead.
+    """
+
+    def __init__(self, repo_path: str) -> None:
+        self.repo_path = repo_path
+
+    async def _run(self, *args: str, errors: str = "strict") -> str:
+        """Run a git command in the repo directory, return stdout.
+
+        Raises LocalGitRefNotFoundError for exit code 128 with revision errors.
+        Raises LocalGitError for other non-zero exit codes.
+        """
+        proc = await asyncio.create_subprocess_exec(
+            "git",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.repo_path,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        stdout = stdout_bytes.decode("utf-8", errors=errors)
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            # Detect missing ref / bad revision errors (exit code 128)
+            if proc.returncode == 128 or "bad revision" in stderr or "does not exist" in stderr:
+                raise LocalGitRefNotFoundError(stderr.strip(), returncode=proc.returncode or 128)
+            raise LocalGitError(stderr.strip(), returncode=proc.returncode or 1)
+
+        return stdout
+
+    # --- Protocol methods ---
+
+    async def get_diff(self, owner: str, repo: str, base_ref: str, head_ref: str) -> DiffData:
+        """Get diff between two refs using local git.
+
+        Uses three-dot diff (base...head) to match GitHub PR behavior.
+        """
+        # Step 1: Get name-status for change types
+        name_status_raw = await self._run("diff", "--name-status", f"{base_ref}...{head_ref}")
+
+        # Step 2: Get full unified diff
+        diff_raw = await self._run("diff", f"{base_ref}...{head_ref}")
+
+        # Parse name-status into a lookup: path -> change_type
+        status_map: dict[str, str] = {}
+        rename_map: dict[str, str] = {}  # old_path -> new_path for renames
+        for line in name_status_raw.strip().split("\n"):
+            if not line.strip():
+                continue
+            parts = line.split("\t")
+            status_code = parts[0]
+            if status_code.startswith("R"):
+                # Rename: R100\told_path\tnew_path
+                old_path = parts[1] if len(parts) > 1 else ""
+                new_path = parts[2] if len(parts) > 2 else old_path
+                status_map[new_path] = "renamed"
+                rename_map[old_path] = new_path
+            else:
+                file_path = parts[1] if len(parts) > 1 else ""
+                status_map[file_path] = _NAME_STATUS_MAP.get(status_code, "modified")
+
+        # Split diff output by file boundaries
+        file_patches = self._split_diff(diff_raw)
+
+        # Build DiffFile list
+        files: list[DiffFile] = []
+        total_additions = 0
+        total_deletions = 0
+        seen_paths: set[str] = set()
+
+        for file_path, patch_text in file_patches.items():
+            # Detect binary files
+            if "Binary files" in patch_text and "differ" in patch_text:
+                change_type = status_map.get(file_path, "modified")
+                files.append(
+                    DiffFile(
+                        path=file_path,
+                        change_type=change_type,
+                        additions=0,
+                        deletions=0,
+                        hunks=[],
+                    )
+                )
+                seen_paths.add(file_path)
+                continue
+
+            hunks = _parse_patch(patch_text)
+            additions = sum(1 for h in hunks for ln in h.lines if ln.type == "add")
+            deletions = sum(1 for h in hunks for ln in h.lines if ln.type == "del")
+            total_additions += additions
+            total_deletions += deletions
+
+            change_type = status_map.get(file_path, "modified")
+
+            files.append(
+                DiffFile(
+                    path=file_path,
+                    change_type=change_type,
+                    additions=additions,
+                    deletions=deletions,
+                    hunks=hunks,
+                )
+            )
+            seen_paths.add(file_path)
+
+        # Include files from name-status that had no diff output (e.g. renames with 100% similarity)
+        for path, change_type in status_map.items():
+            if path not in seen_paths:
+                files.append(
+                    DiffFile(
+                        path=path,
+                        change_type=change_type,
+                        additions=0,
+                        deletions=0,
+                        hunks=[],
+                    )
+                )
+
+        return DiffData(
+            files=files,
+            total_additions=total_additions,
+            total_deletions=total_deletions,
+        )
+
+    async def get_file_tree(self, owner: str, repo: str, ref: str) -> FileTreeNode:
+        """Get file tree at a ref using git ls-tree."""
+        ls_output = await self._run("ls-tree", "-r", "--long", ref)
+
+        entries: list[dict[str, object]] = []
+        for line in ls_output.strip().split("\n"):
+            if not line.strip():
+                continue
+            # Format: <mode> <type> <hash> <size>\t<path>
+            meta, path = line.split("\t", 1)
+            parts = meta.split()
+            if len(parts) < 4:
+                continue
+            mode = parts[0]
+            entry_type = parts[1]
+            size_str = parts[3].strip()
+
+            # Skip submodules (mode 160000, type commit)
+            if entry_type == "commit" or mode == "160000":
+                continue
+
+            size = int(size_str) if size_str.isdigit() else None
+            entries.append({"path": path, "type": entry_type, "size": size})
+
+        return _build_file_tree(entries)
+
+    async def get_file_content(self, owner: str, repo: str, ref: str, path: str) -> FileContent:
+        """Get file content at a ref using git show."""
+        # Get file size first
+        size_str = await self._run("cat-file", "-s", f"{ref}:{path}")
+        size = int(size_str.strip())
+
+        # Get content (use replace for binary safety)
+        content = await self._run("show", f"{ref}:{path}", errors="replace")
+
+        # Truncate if too large
+        truncated = len(content) > _MAX_CONTENT_SIZE
+        if truncated:
+            content = content[:_MAX_CONTENT_SIZE]
+
+        # Count lines
+        line_count = content.count("\n") + (1 if not content.endswith("\n") else 0) if content else 0
+
+        language = _detect_language(path)
+
+        return FileContent(
+            path=path,
+            content=content,
+            size=size,
+            language=language,
+            lines=line_count,
+            truncated=truncated,
+        )
+
+    async def get_behind_count(self, owner: str, repo: str, base_ref: str, head_ref: str) -> int:
+        """Count commits on base not on head using git rev-list."""
+        output = await self._run("rev-list", "--count", f"{head_ref}..{base_ref}")
+        return int(output.strip())
+
+    # --- Internal helpers ---
+
+    @staticmethod
+    def _split_diff(diff_raw: str) -> dict[str, str]:
+        """Split a full git diff output into per-file patches.
+
+        Returns a dict of {file_path: patch_text}.
+        """
+        if not diff_raw.strip():
+            return {}
+
+        result: dict[str, str] = {}
+        # Find all file boundary positions
+        boundaries: list[tuple[int, str]] = []
+        for match in _DIFF_FILE_RE.finditer(diff_raw):
+            boundaries.append((match.start(), match.group(1)))
+
+        for i, (start, file_path) in enumerate(boundaries):
+            end = boundaries[i + 1][0] if i + 1 < len(boundaries) else len(diff_raw)
+            result[file_path] = diff_raw[start:end]
+
+        return result

--- a/app/backend/src/molecules/workflows/project_setup.py
+++ b/app/backend/src/molecules/workflows/project_setup.py
@@ -1,0 +1,171 @@
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from features.projects.schemas.input import ProjectCreate
+from features.projects.service import ProjectService
+from features.workspaces.schemas.input import WorkspaceCreate
+from features.workspaces.service import WorkspaceService
+from molecules.exceptions import MoleculeError
+
+
+@dataclass
+class ProjectSetupResult:
+    project_id: UUID
+    workspace_id: UUID
+    project_name: str
+
+
+class ProjectSetupError(MoleculeError):
+    """Raised when project setup fails.
+
+    Extends MoleculeError so the global molecule_exception_handler in app.py
+    catches it automatically.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+async def _run_git(local_path: str, *args: str) -> tuple[bool, str]:
+    """Run a git command in the given directory, return (success, stdout)."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "-C",
+        local_path,
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout_bytes, _ = await proc.communicate()
+    stdout = stdout_bytes.decode("utf-8").strip()
+    return proc.returncode == 0, stdout
+
+
+def _detect_provider(remote_url: str) -> str:
+    """Detect git provider from a remote URL."""
+    if "github.com" in remote_url:
+        return "github"
+    if "gitlab.com" in remote_url:
+        return "gitlab"
+    if "bitbucket.org" in remote_url:
+        return "bitbucket"
+    return "local"
+
+
+def _normalize_remote_url(remote_url: str) -> str:
+    """Convert SSH remote URLs to HTTPS format for github_repo field."""
+    # git@github.com:owner/repo.git -> https://github.com/owner/repo
+    if remote_url.startswith("git@"):
+        url = remote_url.replace(":", "/", 1).replace("git@", "https://")
+        if url.endswith(".git"):
+            url = url[:-4]
+        return url
+    # Already HTTPS — strip trailing .git
+    if remote_url.endswith(".git"):
+        remote_url = remote_url[:-4]
+    return remote_url
+
+
+@dataclass
+class ProjectSetupWorkflow:
+    """Create a project + workspace from a local git repository path.
+
+    This workflow is a molecule that composes ProjectService and WorkspaceService.
+    It validates the local path, reads git metadata, and creates both entities
+    in a single transaction.
+    """
+
+    db: AsyncSession
+    project_service: ProjectService = field(default_factory=ProjectService)
+    workspace_service: WorkspaceService = field(default_factory=WorkspaceService)
+
+    async def create_local_project(
+        self,
+        user_id: UUID,
+        name: str,
+        local_path: str,
+        description: str | None = None,
+    ) -> ProjectSetupResult:
+        """Create a project and workspace from a local git repository.
+
+        Args:
+            user_id: The authenticated user's ID.
+            name: Project display name.
+            local_path: Absolute path to a local git repository.
+            description: Optional project description.
+        """
+        # 1. Validate local_path exists and is a git repo
+        path = Path(local_path)
+        if not path.exists():
+            raise ProjectSetupError(f"Directory does not exist: {local_path}")
+        if not path.is_dir():
+            raise ProjectSetupError(f"Path is not a directory: {local_path}")
+        if not (path / ".git").exists():
+            raise ProjectSetupError(f"Not a git repository: {local_path}")
+
+        # 2. Read git remote origin URL
+        success, remote_url = await _run_git(local_path, "remote", "get-url", "origin")
+        folder_name = path.name
+        if success and remote_url:
+            normalized_url = _normalize_remote_url(remote_url)
+            provider = _detect_provider(remote_url)
+            repo_url = normalized_url
+            # github_repo field has a validator requiring "github.com" in the URL.
+            # For non-GitHub remotes, use a synthetic GitHub URL as a placeholder.
+            github_repo = normalized_url if provider == "github" else f"https://github.com/local/{folder_name}"
+        else:
+            # No remote — use synthetic URL
+            github_repo = f"https://github.com/local/{folder_name}"
+            repo_url = github_repo
+            provider = "local"
+
+        # 3. Read default branch
+        success, branch = await _run_git(local_path, "symbolic-ref", "--short", "HEAD")
+        default_branch = branch if success and branch else "main"
+
+        # 4. Check for duplicate project name
+        existing = await self.project_service.get_by_name(self.db, name)
+        if existing:
+            raise ProjectSetupError(f"Project '{name}' already exists")
+
+        # 5. Create Project
+        project = await self.project_service.create(
+            self.db,
+            ProjectCreate(
+                name=name,
+                description=description or f"Local repository: {path.name}",
+                owner_id=user_id,
+                github_repo=github_repo,
+                local_path=local_path,
+                metadata_={"source": "local_setup", "local_path": local_path},
+            ),
+        )
+
+        # 6. Create Workspace
+        workspace = await self.workspace_service.create(
+            self.db,
+            WorkspaceCreate(
+                project_id=project.id,
+                name=f"{name} (local)",
+                repo_url=repo_url,
+                provider=provider,
+                default_branch=default_branch,
+                local_path=local_path,
+            ),
+        )
+
+        # 7. Transition project to active
+        project.transition_to("active")
+
+        await self.db.flush()
+
+        return ProjectSetupResult(
+            project_id=project.id,
+            workspace_id=workspace.id,
+            project_name=project.name,
+        )

--- a/app/backend/src/organisms/api/app.py
+++ b/app/backend/src/organisms/api/app.py
@@ -20,10 +20,12 @@ from molecules.events.setup import (
 )
 from molecules.exceptions import MoleculeError
 from molecules.providers.github_adapter import GitHubAPIError
+from molecules.providers.local_git_adapter import LocalGitError
 from organisms.api.dependencies import get_db
 from organisms.api.error_handlers import (
     auth_exception_handler,
     github_exception_handler,
+    local_git_exception_handler,
     molecule_exception_handler,
     state_transition_handler,
 )
@@ -33,6 +35,7 @@ from organisms.api.routers.conversations import router as conversations_router
 from organisms.api.routers.events import router as events_router
 from organisms.api.routers.jobs import router as jobs_router
 from organisms.api.routers.onboarding import router as onboarding_router
+from organisms.api.routers.project_setup import router as project_setup_router
 from organisms.api.routers.projects import router as projects_router
 from organisms.api.routers.stacks import router as stacks_router
 from organisms.api.routers.tasks import router as tasks_router
@@ -128,11 +131,13 @@ def create_app() -> FastAPI:
     app.include_router(events_router, prefix="/api/v1")
     app.include_router(onboarding_router, prefix="/api/v1")
     app.include_router(workspaces_router, prefix="/api/v1")
+    app.include_router(project_setup_router, prefix="/api/v1")
 
     # Error handlers
     app.add_exception_handler(AuthError, auth_exception_handler)  # type: ignore[arg-type]
     app.add_exception_handler(MoleculeError, molecule_exception_handler)  # type: ignore[arg-type]
     app.add_exception_handler(GitHubAPIError, github_exception_handler)  # type: ignore[arg-type]
+    app.add_exception_handler(LocalGitError, local_git_exception_handler)  # type: ignore[arg-type]
     app.add_exception_handler(InvalidStateTransitionError, state_transition_handler)  # type: ignore[arg-type]
 
     return app

--- a/app/backend/src/organisms/api/error_handlers.py
+++ b/app/backend/src/organisms/api/error_handlers.py
@@ -17,6 +17,10 @@ from molecules.providers.github_adapter import (
     GitHubNotFoundError,
     GitHubRateLimitError,
 )
+from molecules.providers.local_git_adapter import (
+    LocalGitError,
+    LocalGitRefNotFoundError,
+)
 
 EXCEPTION_MAP: dict[type[MoleculeError], tuple[int, str]] = {
     ConversationNotFoundError: (404, "Conversation not found"),
@@ -43,6 +47,12 @@ async def auth_exception_handler(request: Request, exc: AuthError) -> JSONRespon
 async def state_transition_handler(request: Request, exc: InvalidStateTransitionError) -> JSONResponse:
     """Handle invalid state transitions as 409 Conflict."""
     return JSONResponse(status_code=409, content={"detail": str(exc)})
+
+
+async def local_git_exception_handler(request: Request, exc: LocalGitError) -> JSONResponse:
+    if isinstance(exc, LocalGitRefNotFoundError):
+        return JSONResponse(status_code=404, content={"detail": str(exc)})
+    return JSONResponse(status_code=500, content={"detail": f"Local git error: {exc}"})
 
 
 async def github_exception_handler(request: Request, exc: GitHubAPIError) -> JSONResponse:

--- a/app/backend/src/organisms/api/routers/project_setup.py
+++ b/app/backend/src/organisms/api/routers/project_setup.py
@@ -1,0 +1,178 @@
+import json
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from features.projects.service import ProjectService
+from features.stacks.schemas.input import StackCreate
+from features.stacks.service import StackService
+from features.workspaces.service import WorkspaceService
+from molecules.entities.stack_entity import StackEntity
+from molecules.workflows.project_setup import ProjectSetupError, ProjectSetupWorkflow
+from organisms.api.dependencies import CurrentUser, DatabaseSession
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+# --- Request / Response schemas ---
+
+
+class ProjectSetupRequest(BaseModel):
+    name: str
+    local_path: str
+    description: str | None = None
+
+
+class ProjectSetupResponse(BaseModel):
+    project_id: str
+    workspace_id: str
+    project_name: str
+
+
+class SyncedStackInfo(BaseModel):
+    stack_id: str
+    name: str
+    created: bool
+    branch_count: int
+
+
+class SyncStacksResponse(BaseModel):
+    synced: list[SyncedStackInfo]
+    skipped: list[str]
+
+
+# --- Endpoint ---
+
+
+@router.post("/setup", response_model=ProjectSetupResponse, status_code=201)
+async def setup_project(
+    body: ProjectSetupRequest,
+    user: CurrentUser,
+    db: DatabaseSession,
+) -> ProjectSetupResponse:
+    """Create a project + workspace from a local git repository.
+
+    Validates that local_path is a git repo, reads remote/branch metadata,
+    and creates both entities in a single transaction.
+    """
+    workflow = ProjectSetupWorkflow(db)
+    try:
+        result = await workflow.create_local_project(
+            user_id=user.id,
+            name=body.name,
+            local_path=body.local_path,
+            description=body.description,
+        )
+    except ProjectSetupError as e:
+        raise HTTPException(status_code=400, detail=e.message) from None
+
+    await db.commit()
+
+    return ProjectSetupResponse(
+        project_id=str(result.project_id),
+        workspace_id=str(result.workspace_id),
+        project_name=result.project_name,
+    )
+
+
+# --- Stack sync from local CLI state ---
+
+STACKS_DIR = Path.home() / ".claude" / "stacks"
+
+
+@router.post("/{project_id}/sync-stacks", response_model=SyncStacksResponse)
+async def sync_stacks_from_cli(
+    project_id: UUID,
+    db: DatabaseSession,
+) -> SyncStacksResponse:
+    """Sync stacks from the local stack CLI state file into the database.
+
+    Reads ~/.claude/stacks/{repo_name}.json, creates or updates stacks
+    and branches for the given project.
+    """
+    project_service = ProjectService()
+    workspace_service = WorkspaceService()
+    stack_service = StackService()
+
+    # 1. Look up project and workspace
+    project = await project_service.get(db, project_id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    workspace = await workspace_service.get_by_project(db, project_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="No workspace found for project")
+
+    # 2. Derive the CLI state file path from github_repo
+    repo_name = project.github_repo.rstrip("/").split("/")[-1]
+    state_file = STACKS_DIR / f"{repo_name}.json"
+
+    if not state_file.exists():
+        raise HTTPException(
+            status_code=404,
+            detail=f"No stack CLI state file found at {state_file}",
+        )
+
+    # 3. Parse the state file
+    try:
+        cli_state = json.loads(state_file.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        raise HTTPException(status_code=400, detail=f"Failed to read state file: {e}") from None
+
+    stacks_data: dict[str, Any] = cli_state.get("stacks", {})
+    if not stacks_data:
+        return SyncStacksResponse(synced=[], skipped=[])
+
+    # 4. Sync each stack
+    entity = StackEntity(db)
+    synced: list[SyncedStackInfo] = []
+    skipped: list[str] = []
+
+    for stack_name, stack_info in stacks_data.items():
+        branches = stack_info.get("branches", [])
+        if not branches:
+            skipped.append(stack_name)
+            continue
+
+        trunk = stack_info.get("trunk", "main")
+
+        # Create or find existing stack
+        stack = await stack_service.get_by_name(db, project_id, stack_name)
+        was_created = False
+        if stack is None:
+            stack = await stack_service.create(
+                db,
+                StackCreate(project_id=project_id, name=stack_name, trunk=trunk),
+            )
+            was_created = True
+
+        # Build branch sync data
+        branches_data = []
+        for i, branch in enumerate(branches):
+            branches_data.append(
+                {
+                    "name": branch["name"],
+                    "position": i + 1,
+                    "head_sha": branch.get("tip"),
+                    "pr_number": branch.get("pr"),
+                    "pr_url": None,
+                }
+            )
+
+        # Sync branches using existing entity method
+        await entity.sync_stack(stack.id, workspace.id, branches_data)
+
+        synced.append(
+            SyncedStackInfo(
+                stack_id=str(stack.id),
+                name=stack_name,
+                created=was_created,
+                branch_count=len(branches_data),
+            )
+        )
+
+    await db.commit()
+    return SyncStacksResponse(synced=synced, skipped=skipped)

--- a/app/frontend/src/AppRouter.tsx
+++ b/app/frontend/src/AppRouter.tsx
@@ -4,6 +4,7 @@ import { RegisterPage } from "@/pages/RegisterPage";
 import { GitHubCallbackPage } from "@/pages/GitHubCallbackPage";
 import { OnboardingPage } from "@/pages/OnboardingPage";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { ProjectProvider } from "@/contexts/ProjectContext";
 import { AppLayout } from "@/components/templates/AppLayout";
 import { DashboardPage } from "@/pages/DashboardPage";
 import { WorkspaceDetailPage } from "@/pages/WorkspaceDetailPage";
@@ -30,7 +31,9 @@ export function AppRouter() {
         element={
           <ProtectedRoute>
             <AuthGate>
-              <AppLayout />
+              <ProjectProvider>
+                <AppLayout />
+              </ProjectProvider>
             </AuthGate>
           </ProtectedRoute>
         }

--- a/app/frontend/src/components/atoms/Dialog/Dialog.tsx
+++ b/app/frontend/src/components/atoms/Dialog/Dialog.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface DialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+}
+
+function Dialog({ isOpen, onClose, title, children }: DialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocus = useRef<HTMLElement | null>(null);
+
+  // Focus management: save previous focus, restore on close
+  useEffect(() => {
+    if (isOpen) {
+      previousFocus.current = document.activeElement as HTMLElement;
+
+      // Focus first focusable element inside dialog
+      requestAnimationFrame(() => {
+        const focusable = dialogRef.current?.querySelector<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        focusable?.focus();
+      });
+    } else if (previousFocus.current) {
+      previousFocus.current.focus();
+      previousFocus.current = null;
+    }
+  }, [isOpen]);
+
+  // ESC to close
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      {/* Overlay */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* Dialog panel */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        className="relative z-10 w-full max-w-md mx-4 rounded-lg border border-[var(--border)] bg-[var(--bg-surface)] shadow-xl"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--border-muted)]">
+          <h2 className="text-base font-semibold text-[var(--fg-default)]">
+            {title}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-md text-[var(--fg-subtle)] hover:text-[var(--fg-default)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-5 py-4">{children}</div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+Dialog.displayName = "Dialog";
+
+export { Dialog };
+export type { DialogProps };

--- a/app/frontend/src/components/atoms/Dialog/index.ts
+++ b/app/frontend/src/components/atoms/Dialog/index.ts
@@ -1,0 +1,2 @@
+export { Dialog } from "./Dialog";
+export type { DialogProps } from "./Dialog";

--- a/app/frontend/src/components/atoms/Icon/Icon.tsx
+++ b/app/frontend/src/components/atoms/Icon/Icon.tsx
@@ -2,6 +2,9 @@ import { forwardRef, type SVGAttributes } from "react";
 import { cn } from "@/lib/utils";
 
 const iconPaths: Record<string, React.ReactNode> = {
+  "chevron-left": (
+    <polyline points="15 18 9 12 15 6" />
+  ),
   "chevron-right": (
     <polyline points="9 18 15 12 9 6" />
   ),

--- a/app/frontend/src/components/atoms/index.ts
+++ b/app/frontend/src/components/atoms/index.ts
@@ -89,3 +89,6 @@ export type { ChatNoticeProps } from "./ChatNotice";
 
 export { UrlInput } from "./UrlInput";
 export type { UrlInputProps } from "./UrlInput";
+
+export { Dialog } from "./Dialog";
+export type { DialogProps } from "./Dialog";

--- a/app/frontend/src/components/organisms/AddProjectDialog/AddProjectDialog.tsx
+++ b/app/frontend/src/components/organisms/AddProjectDialog/AddProjectDialog.tsx
@@ -1,0 +1,203 @@
+import { useState, useCallback, useEffect } from "react";
+import { Dialog } from "@/components/atoms";
+import { useActiveProject } from "@/contexts/ProjectContext";
+import { useCreateLocalProject } from "@/hooks/useCreateLocalProject";
+
+interface AddProjectDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+function AddProjectDialog({ isOpen, onClose }: AddProjectDialogProps) {
+  const { setActiveProject } = useActiveProject();
+  const mutation = useCreateLocalProject();
+
+  const [name, setName] = useState("");
+  const [localPath, setLocalPath] = useState("");
+  const [description, setDescription] = useState("");
+  const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
+
+  // Reset form on open
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+      setLocalPath("");
+      setDescription("");
+      setNameManuallyEdited(false);
+      mutation.reset();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Auto-derive name from folder name if user hasn't manually edited it
+  const handleLocalPathChange = useCallback(
+    (value: string) => {
+      setLocalPath(value);
+      if (!nameManuallyEdited) {
+        const parts = value.replace(/\/+$/, "").split("/");
+        const folderName = parts[parts.length - 1] ?? "";
+        setName(folderName);
+      }
+    },
+    [nameManuallyEdited]
+  );
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+    setNameManuallyEdited(true);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!name.trim() || !localPath.trim()) return;
+
+      try {
+        const result = await mutation.mutateAsync({
+          name: name.trim(),
+          local_path: localPath.trim(),
+          description: description.trim() || undefined,
+        });
+
+        // Set the new project as active
+        setActiveProject({
+          id: result.project_id,
+          name: result.project_name,
+          github_repo: "",
+          owner_id: "",
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        });
+
+        onClose();
+      } catch {
+        // Error is handled by mutation.error below
+      }
+    },
+    [name, localPath, description, mutation, setActiveProject, onClose]
+  );
+
+  // Extract error message from mutation error
+  const errorMessage = mutation.error
+    ? (mutation.error as { detail?: string }).detail ??
+      (mutation.error as Error).message ??
+      "Failed to create project"
+    : null;
+
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Add Project">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {/* Local Path */}
+        <div>
+          <label
+            htmlFor="add-project-path"
+            className="block text-xs font-medium text-[var(--fg-muted)] mb-1"
+          >
+            Local Path <span className="text-[var(--red)]">*</span>
+          </label>
+          <div className="flex gap-2">
+            <input
+              id="add-project-path"
+              type="text"
+              value={localPath}
+              onChange={(e) => handleLocalPathChange(e.target.value)}
+              placeholder="/Users/you/Projects/my-repo"
+              required
+              className="flex-1 px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--bg-canvas)] text-sm text-[var(--fg-default)] placeholder:text-[var(--fg-subtle)] focus:outline-none focus:border-[var(--accent)] transition-colors"
+            />
+            {"showDirectoryPicker" in window && (
+              <button
+                type="button"
+                onClick={async () => {
+                  try {
+                    const handle = await (window as any).showDirectoryPicker({ mode: "read" });
+                    // Resolve the full path — unfortunately the File System Access API
+                    // only gives us the folder name, not the full path. We set it as a
+                    // hint and let the user confirm/edit.
+                    handleLocalPathChange(handle.name);
+                  } catch {
+                    // User cancelled the picker
+                  }
+                }}
+                className="px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--bg-canvas)] text-sm text-[var(--fg-muted)] hover:text-[var(--fg-default)] hover:border-[var(--accent)] transition-colors shrink-0"
+                title="Browse for folder"
+              >
+                Browse
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-[10px] text-[var(--fg-subtle)]">
+            Absolute path to a local git repository
+          </p>
+        </div>
+
+        {/* Name */}
+        <div>
+          <label
+            htmlFor="add-project-name"
+            className="block text-xs font-medium text-[var(--fg-muted)] mb-1"
+          >
+            Name <span className="text-[var(--red)]">*</span>
+          </label>
+          <input
+            id="add-project-name"
+            type="text"
+            value={name}
+            onChange={(e) => handleNameChange(e.target.value)}
+            placeholder="my-project"
+            required
+            className="w-full px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--bg-canvas)] text-sm text-[var(--fg-default)] placeholder:text-[var(--fg-subtle)] focus:outline-none focus:border-[var(--accent)] transition-colors"
+          />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label
+            htmlFor="add-project-description"
+            className="block text-xs font-medium text-[var(--fg-muted)] mb-1"
+          >
+            Description
+          </label>
+          <textarea
+            id="add-project-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional project description"
+            rows={2}
+            className="w-full px-3 py-2 rounded-md border border-[var(--border)] bg-[var(--bg-canvas)] text-sm text-[var(--fg-default)] placeholder:text-[var(--fg-subtle)] focus:outline-none focus:border-[var(--accent)] transition-colors resize-none"
+          />
+        </div>
+
+        {/* Error message */}
+        {errorMessage && (
+          <div className="px-3 py-2 rounded-md bg-[var(--red)]/10 border border-[var(--red)]/20 text-xs text-[var(--red)]">
+            {errorMessage}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 rounded-md text-sm text-[var(--fg-muted)] hover:text-[var(--fg-default)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!name.trim() || !localPath.trim() || mutation.isPending}
+            className="px-4 py-1.5 rounded-md text-sm font-medium bg-[var(--accent)] text-[var(--fg-on-accent)] hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {mutation.isPending ? "Creating..." : "Create Project"}
+          </button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}
+
+AddProjectDialog.displayName = "AddProjectDialog";
+
+export { AddProjectDialog };
+export type { AddProjectDialogProps };

--- a/app/frontend/src/components/organisms/AddProjectDialog/index.ts
+++ b/app/frontend/src/components/organisms/AddProjectDialog/index.ts
@@ -1,0 +1,2 @@
+export { AddProjectDialog } from "./AddProjectDialog";
+export type { AddProjectDialogProps } from "./AddProjectDialog";

--- a/app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx
+++ b/app/frontend/src/components/organisms/GlobalSidebar/GlobalSidebar.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Icon } from "@/components/atoms";
-import { useProjectList } from "@/hooks/useProjectList";
+import { useActiveProject } from "@/contexts/ProjectContext";
 import { useTaskList } from "@/hooks/useTaskList";
 import { useStackList } from "@/hooks/useStackList";
+import { ProjectSwitcher } from "./ProjectSwitcher";
+import { AddProjectDialog } from "@/components/organisms/AddProjectDialog";
 import type { Task } from "@/types/task";
 import type { Stack } from "@/types/stack";
 
@@ -82,14 +85,20 @@ function StackRow({
   );
 }
 
-function GlobalSidebar() {
+interface GlobalSidebarProps {
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+}
+
+function GlobalSidebar({ collapsed = false, onToggleCollapse }: GlobalSidebarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const activeNav = navFromPath(location.pathname);
+  const [showAddProject, setShowAddProject] = useState(false);
 
   // Load project context
-  const { data: projects } = useProjectList();
-  const projectId = projects[0]?.id;
+  const { activeProject } = useActiveProject();
+  const projectId = activeProject?.id;
 
   // Load tasks & stacks for sidebar
   const { data: tasks } = useTaskList(projectId);
@@ -104,17 +113,51 @@ function GlobalSidebar() {
   const workspaceMatch = location.pathname.match(/^\/workspaces\/(.+)/);
   const activeTaskId = workspaceMatch?.[1] ?? null;
 
+  // --- Collapsed view: icon-only rail ---
+  if (collapsed) {
+    return (
+      <aside className="flex flex-col h-full w-12 border-r border-[var(--border)] bg-[var(--bg-surface)] shrink-0">
+        {/* Expand button */}
+        <button
+          onClick={onToggleCollapse}
+          className="px-3 py-3 hover:bg-[var(--bg-canvas-inset)] transition-colors border-b border-[var(--border-muted)]"
+          title="Expand sidebar"
+        >
+          <Icon name="chevron-right" size="sm" className="text-[var(--fg-subtle)]" />
+        </button>
+
+        {/* Nav icons */}
+        <nav className="py-2 space-y-1 flex flex-col items-center">
+          <NavIconButton
+            icon="grid"
+            active={activeNav === "dashboard"}
+            onClick={() => navigate("/")}
+            title="Dashboard"
+          />
+          <NavIconButton
+            icon="layout"
+            active={activeNav === "workspaces"}
+            onClick={() => navigate("/workspaces")}
+            title="Workspaces"
+          />
+          <NavIconButton
+            icon="git-branch"
+            active={activeNav === "stacks"}
+            onClick={() => navigate("/stacks")}
+            title="Stacks"
+          />
+        </nav>
+
+        <AddProjectDialog isOpen={showAddProject} onClose={() => setShowAddProject(false)} />
+      </aside>
+    );
+  }
+
+  // --- Expanded view ---
   return (
-    <aside className="flex flex-col h-full w-[260px] border-r border-[var(--border)] bg-[var(--bg-surface)]">
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-[var(--border-muted)]">
-        <div className="flex items-center gap-2">
-          <Icon name="git-branch" size="sm" className="text-[var(--accent)]" />
-          <span className="text-sm font-semibold text-[var(--fg-default)] tracking-tight">
-            Stack Bench
-          </span>
-        </div>
-      </div>
+    <aside className="flex flex-col h-full w-[260px] border-r border-[var(--border)] bg-[var(--bg-surface)] shrink-0">
+      {/* Project Switcher */}
+      <ProjectSwitcher onAddProject={() => setShowAddProject(true)} />
 
       {/* Navigation */}
       <nav className="px-2 py-2 space-y-0.5">
@@ -178,20 +221,29 @@ function GlobalSidebar() {
       </div>
 
       {/* Bottom actions */}
-      <div className="px-3 py-3 border-t border-[var(--border-muted)] space-y-2">
+      <div className="px-3 py-2 border-t border-[var(--border-muted)] flex items-center justify-between">
         <button
           onClick={() => navigate("/?new=1")}
-          className="w-full flex items-center gap-2 px-3 py-1.5 rounded-md text-sm text-[var(--accent)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
+          className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm text-[var(--accent)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
         >
           <Icon name="plus" size="xs" />
           New Task
         </button>
+        <button
+          onClick={onToggleCollapse}
+          className="p-1.5 rounded-md text-[var(--fg-subtle)] hover:text-[var(--fg-default)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
+          title="Collapse sidebar"
+        >
+          <Icon name="chevron-left" size="xs" />
+        </button>
       </div>
+
+      <AddProjectDialog isOpen={showAddProject} onClose={() => setShowAddProject(false)} />
     </aside>
   );
 }
 
-/** Sidebar nav button */
+/** Sidebar nav button (expanded) */
 function NavButton({
   label,
   icon,
@@ -214,6 +266,33 @@ function NavButton({
     >
       <Icon name={icon as any} size="sm" className={active ? "text-[var(--accent)]" : ""} />
       {label}
+    </button>
+  );
+}
+
+/** Sidebar nav button (collapsed — icon only) */
+function NavIconButton({
+  icon,
+  active,
+  onClick,
+  title,
+}: {
+  icon: string;
+  active: boolean;
+  onClick: () => void;
+  title: string;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      title={title}
+      className={`p-2 rounded-md transition-colors ${
+        active
+          ? "bg-[var(--bg-canvas)] text-[var(--accent)]"
+          : "text-[var(--fg-muted)] hover:text-[var(--fg-default)] hover:bg-[var(--bg-canvas-inset)]"
+      }`}
+    >
+      <Icon name={icon as any} size="sm" />
     </button>
   );
 }

--- a/app/frontend/src/components/organisms/GlobalSidebar/ProjectSwitcher.tsx
+++ b/app/frontend/src/components/organisms/GlobalSidebar/ProjectSwitcher.tsx
@@ -1,0 +1,144 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Icon } from "@/components/atoms";
+import { useActiveProject } from "@/contexts/ProjectContext";
+import { apiClient } from "@/generated/api/client";
+
+interface ProjectSwitcherProps {
+  onAddProject: () => void;
+}
+
+function ProjectSwitcher({ onAddProject }: ProjectSwitcherProps) {
+  const { activeProject, setActiveProject, projects } = useActiveProject();
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClick(e: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [isOpen]);
+
+  // Close on ESC
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setIsOpen(false);
+    }
+
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [isOpen]);
+
+  const queryClient = useQueryClient();
+  const syncMutation = useMutation({
+    mutationFn: (projectId: string) =>
+      apiClient.post<{ synced: unknown[]; skipped: string[] }>(
+        `/api/v1/projects/${projectId}/sync-stacks`,
+        {}
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["stacks"] });
+    },
+  });
+
+  const handleSync = useCallback(() => {
+    if (activeProject?.id) {
+      syncMutation.mutate(activeProject.id);
+    }
+  }, [activeProject?.id, syncMutation]);
+
+  const displayName = activeProject?.name ?? "Add a project";
+
+  return (
+    <div ref={containerRef} className="relative border-b border-[var(--border-muted)]">
+      <div className="flex items-center">
+        <button
+          onClick={() => (projects.length > 0 ? setIsOpen(!isOpen) : onAddProject())}
+          className="flex-1 flex items-center gap-2 px-4 py-3 hover:bg-[var(--bg-canvas-inset)] transition-colors min-w-0"
+        >
+          <Icon name="folder" size="sm" className="text-[var(--accent)] shrink-0" />
+          <span className="text-sm font-semibold text-[var(--fg-default)] tracking-tight truncate flex-1 text-left">
+            {displayName}
+          </span>
+          {projects.length > 0 && (
+            <Icon
+              name="chevron-down"
+              size="xs"
+              className={`text-[var(--fg-subtle)] shrink-0 transition-transform ${isOpen ? "rotate-180" : ""}`}
+            />
+          )}
+        </button>
+        {activeProject && (
+          <button
+            onClick={handleSync}
+            disabled={syncMutation.isPending}
+            title="Sync stacks from CLI"
+            className="px-2 py-3 text-[var(--fg-subtle)] hover:text-[var(--accent)] transition-colors disabled:opacity-50"
+          >
+            <Icon
+              name="git-branch"
+              size="xs"
+              className={syncMutation.isPending ? "animate-spin" : ""}
+            />
+          </button>
+        )}
+      </div>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 right-0 z-50 mt-0.5 mx-2 rounded-md border border-[var(--border)] bg-[var(--bg-surface)] shadow-lg overflow-hidden">
+          <div className="py-1 max-h-[240px] overflow-y-auto">
+            {projects.map((project) => (
+              <button
+                key={project.id}
+                onClick={() => {
+                  setActiveProject(project);
+                  setIsOpen(false);
+                }}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-left text-sm transition-colors ${
+                  project.id === activeProject?.id
+                    ? "bg-[var(--bg-canvas)] text-[var(--fg-default)]"
+                    : "text-[var(--fg-muted)] hover:bg-[var(--bg-canvas-inset)] hover:text-[var(--fg-default)]"
+                }`}
+              >
+                <span className="flex-1 truncate">{project.name}</span>
+                {project.id === activeProject?.id && (
+                  <Icon name="check" size="xs" className="text-[var(--accent)] shrink-0" />
+                )}
+              </button>
+            ))}
+          </div>
+
+          <div className="border-t border-[var(--border-muted)]">
+            <button
+              onClick={() => {
+                setIsOpen(false);
+                onAddProject();
+              }}
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm text-[var(--accent)] hover:bg-[var(--bg-canvas-inset)] transition-colors"
+            >
+              <Icon name="plus" size="xs" />
+              Add Project
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ProjectSwitcher.displayName = "ProjectSwitcher";
+
+export { ProjectSwitcher };

--- a/app/frontend/src/components/templates/AppLayout/AppLayout.tsx
+++ b/app/frontend/src/components/templates/AppLayout/AppLayout.tsx
@@ -1,10 +1,25 @@
+import { useState, useCallback } from "react";
 import { Outlet } from "react-router-dom";
 import { GlobalSidebar } from "@/components/organisms/GlobalSidebar";
 
+const STORAGE_KEY = "stack-bench-sidebar-collapsed";
+
 function AppLayout() {
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem(STORAGE_KEY) === "true"
+  );
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
   return (
     <div className="flex h-screen bg-[var(--bg-canvas)] text-[var(--fg-default)] font-[family-name:var(--font-sans)]">
-      <GlobalSidebar />
+      <GlobalSidebar collapsed={collapsed} onToggleCollapse={toggleCollapsed} />
       <main className="flex-1 flex flex-col min-w-0">
         <Outlet />
       </main>

--- a/app/frontend/src/contexts/ProjectContext.tsx
+++ b/app/frontend/src/contexts/ProjectContext.tsx
@@ -1,0 +1,83 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { useProjectList } from "@/hooks/useProjectList";
+
+const STORAGE_KEY = "stack-bench-active-project";
+
+interface Project {
+  id: string;
+  name: string;
+  github_repo: string;
+  owner_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ProjectContextValue {
+  activeProject: Project | null;
+  setActiveProject: (project: Project | null) => void;
+  projects: Project[];
+  isLoading: boolean;
+}
+
+const ProjectContext = createContext<ProjectContextValue | null>(null);
+
+export function ProjectProvider({ children }: { children: ReactNode }) {
+  const { data: projects, loading } = useProjectList();
+  const [activeProjectId, setActiveProjectId] = useState<string | null>(() =>
+    localStorage.getItem(STORAGE_KEY)
+  );
+
+  // Resolve the active project from the list
+  const activeProject =
+    projects.find((p) => p.id === activeProjectId) ?? projects[0] ?? null;
+
+  // Sync the resolved project ID back (handles case where saved ID is stale)
+  useEffect(() => {
+    if (!loading && projects.length > 0 && activeProject) {
+      if (activeProject.id !== activeProjectId) {
+        setActiveProjectId(activeProject.id);
+        localStorage.setItem(STORAGE_KEY, activeProject.id);
+      }
+    }
+  }, [loading, projects, activeProject, activeProjectId]);
+
+  const setActiveProject = useCallback((project: Project | null) => {
+    if (project) {
+      setActiveProjectId(project.id);
+      localStorage.setItem(STORAGE_KEY, project.id);
+    } else {
+      setActiveProjectId(null);
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  return (
+    <ProjectContext.Provider
+      value={{
+        activeProject,
+        setActiveProject,
+        projects,
+        isLoading: loading,
+      }}
+    >
+      {children}
+    </ProjectContext.Provider>
+  );
+}
+
+export function useActiveProject(): ProjectContextValue {
+  const ctx = useContext(ProjectContext);
+  if (!ctx) {
+    throw new Error(
+      "useActiveProject must be used within a ProjectProvider"
+    );
+  }
+  return ctx;
+}

--- a/app/frontend/src/hooks/useCreateLocalProject.ts
+++ b/app/frontend/src/hooks/useCreateLocalProject.ts
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/generated/api/client";
+import { projectListKeys } from "@/hooks/useProjectList";
+
+interface CreateLocalProjectInput {
+  name: string;
+  local_path: string;
+  description?: string;
+}
+
+interface CreateLocalProjectResult {
+  project_id: string;
+  workspace_id: string;
+  project_name: string;
+}
+
+export function useCreateLocalProject() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: CreateLocalProjectInput) =>
+      apiClient.post<CreateLocalProjectResult>(
+        "/api/v1/projects/setup",
+        input
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: projectListKeys.all });
+    },
+  });
+}
+
+export type { CreateLocalProjectInput, CreateLocalProjectResult };

--- a/app/frontend/src/pages/DashboardPage.tsx
+++ b/app/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { Icon } from "@/components/atoms";
-import { useProjectList } from "@/hooks/useProjectList";
+import { useActiveProject } from "@/contexts/ProjectContext";
 import { useTaskList } from "@/hooks/useTaskList";
 import type { Task } from "@/types/task";
 
@@ -59,8 +59,8 @@ function demoPipeline(task: Task): PipelineStep[] {
 }
 
 function DashboardPage() {
-  const { data: projects } = useProjectList();
-  const projectId = projects[0]?.id;
+  const { activeProject } = useActiveProject();
+  const projectId = activeProject?.id;
   const { data: tasks, loading } = useTaskList(projectId);
 
   if (loading) {

--- a/app/frontend/src/pages/StacksListPage.tsx
+++ b/app/frontend/src/pages/StacksListPage.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { Icon } from "@/components/atoms";
-import { useProjectList } from "@/hooks/useProjectList";
+import { useActiveProject } from "@/contexts/ProjectContext";
 import { useStackList } from "@/hooks/useStackList";
 import { useStackDetail } from "@/hooks/useStackDetail";
 import type { Stack, BranchWithPR } from "@/types/stack";
@@ -37,8 +37,8 @@ const STATE_CONFIG: Record<string, { color: string; label: string }> = {
 };
 
 function StacksListPage() {
-  const { data: projects } = useProjectList();
-  const projectId = projects[0]?.id;
+  const { activeProject } = useActiveProject();
+  const projectId = activeProject?.id;
   const { data: stacks, loading } = useStackList(projectId);
 
   if (loading) {


### PR DESCRIPTION
## Summary

- **LocalGitAdapter**: reads diffs, file trees, and file content from local git clones via subprocess — no GitHub App installation needed. StackAPI resolves adapter per-workspace (local_path → local git, otherwise → GitHub).
- **Project setup flow**: `POST /api/v1/projects/setup` composite endpoint + frontend project switcher, Add Project dialog, active project context with localStorage persistence.
- **Stack sync from CLI**: `POST /api/v1/projects/{id}/sync-stacks` reads `~/.claude/stacks/{repo}.json` and creates/updates all stacks and branches.
- **Collapsible global sidebar** with icon-only rail mode, persisted to localStorage.
- 47 new tests (LocalGitAdapter, ProjectSetupWorkflow, reader resolution)

## Test plan

- [x] `just quality` passes (726 tests, mypy, lint clean)
- [x] Project switcher shows both projects, switches correctly
- [x] Add Project dialog creates project + workspace from local path
- [x] Stack sync imports all stacks from CLI state file
- [x] Sidebar collapses/expands, state persists across refresh
- [x] Stack detail page renders diffs from local git clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)